### PR TITLE
Fix: Landless duke of Meath

### DIFF
--- a/history/titles/k_ireland.txt
+++ b/history/titles/k_ireland.txt
@@ -3,7 +3,7 @@ k_ireland = {
 	1066.1.1 = { change_development_level = 6 }
 	
 	846.1.1 = {
-		holder = 131501 # Máel Sechnaill
+		holder = 131501 # Mï¿½el Sechnaill
 	}
 	862.11.22 = {
 		holder = 0
@@ -12,7 +12,7 @@ k_ireland = {
 		holder = 131505 #Mael Sechnaill Mor
 	}
 	1002.1.1 = {
-		holder = 900 # Brian Bóruma
+		holder = 900 # Brian Bï¿½ruma
 	}
 	1015.3.23 = {
 		holder = 131505 #Mael Sechnaill Mor (restored)
@@ -25,9 +25,7 @@ k_ireland = {
 
 d_meath = {
 	862.11.22 = {
-		holder = 944
-		succession_laws = { gaelic_elective_succession_law }
-		government = tribal_government
+		holder = 0
 	}
 	879.11.20 = {
 		holder = 0
@@ -79,7 +77,7 @@ c_dublin = {
 		holder = 5790 # Olaf Cuaran
 	}
 	980.1.1 = {
-		holder = 131521 # Glúniairn
+		holder = 131521 # Glï¿½niairn
 	}
 	989.1.1 = {
 		holder = 1025 #Sihtric
@@ -97,7 +95,7 @@ c_dublin = {
 		holder = 920 #Donnchad son of Domnall Remar
 	}
 	1089.7.1 = {
-		holder = 923 #Énna son of Diarmait
+		holder = 923 #ï¿½nna son of Diarmait
 	}
 	1092.7.1 = {
 		holder = 5788 #Gofraid Meranach king of Mann
@@ -106,7 +104,7 @@ c_dublin = {
 		holder = 83250 #Domnall Ua Briain son of High King Muirchertach
 	}
 	1118.7.1 = {
-		holder = 83192 #Énna son of Donnchad
+		holder = 83192 #ï¿½nna son of Donnchad
 	}
 	1126.7.1 = {
 		holder = 83240 #Thorkil
@@ -118,7 +116,7 @@ c_dublin = {
 		holder = 83247 #Ottar son of Ottar
 	}
 	1148.7.1 = {
-		holder = 83242 #Bróðir son of Thorkil
+		holder = 83242 #Brï¿½ï¿½ir son of Thorkil
 	}
 	1160.7.1 = {
 		holder = 83243 #Ascall son of Ragnall
@@ -198,14 +196,13 @@ c_athlone = {
 		holder = 7274 #Donnachad son of Donmnall Ua Neill
 	}
 	797.2.6 = {
-		holder = 7276 #Máel Ruanaid son of Donnachad Ua Neill
+		holder = 7276 #Mï¿½el Ruanaid son of Donnachad Ua Neill
 	}
 	843.1.1 = {
-		holder = 131501 #Máel Sechnaill son of Máel Ruanaid Ua Neill
+		holder = 131501 #Mï¿½el Sechnaill son of Mï¿½el Ruanaid Ua Neill
 	}
 	862.11.22 = {
-		holder = 131502 #Flann Sinna son of Máel Sechnaill Ua Neill
-		liege = d_meath
+		holder = 131502 #Flann Sinna son of Mï¿½el Sechnaill Ua Neill
 	}
 	879.11.20 = {
 		liege = 0
@@ -232,19 +229,19 @@ c_athlone = {
 		holder = 131504 #Domnall Donn son of Donnchad Donn Ua Neill
 	}
 	952.1.1 = {
-		holder = 83135 #Muirchertach son of Máel Ruanaid
+		holder = 83135 #Muirchertach son of Mï¿½el Ruanaid
 	}
 	960.7.1 = {
-		holder = 83135 #Muirchertach son of Máel Ruanaid
+		holder = 83135 #Muirchertach son of Mï¿½el Ruanaid
 	}
 	976.7.1 = {
-		holder = 131505 #Máel Sechnaill Mór son of Domnall Donn Ua Neill
+		holder = 131505 #Mï¿½el Sechnaill Mï¿½r son of Domnall Donn Ua Neill
 	}
 	1022.9.2 = {
-		holder = 83128 #Máel-Sechnaill Got
+		holder = 83128 #Mï¿½el-Sechnaill Got
 	}
 	1025.7.1 = {
-		holder = 83136 #Róen son of Muirchertach
+		holder = 83136 #Rï¿½en son of Muirchertach
 	}
 	1027.7.1 = {
 		holder = 83130 #Domnall Got
@@ -256,19 +253,19 @@ c_athlone = {
 		holder = 6118 #Murchad son of Flann
 	}
 	1076.7.1 = {
-		holder = 6119 #Máel Sechlainn Bán son of Conchobar
+		holder = 6119 #Mï¿½el Sechlainn Bï¿½n son of Conchobar
 	}
 	1087.7.1 = {
 		holder = 6117 #Domnall son of Flann
 	}
 	1094.1.1 = {
-		holder = 83142 #Conchobar son of Máel Sechlainn Bán
+		holder = 83142 #Conchobar son of Mï¿½el Sechlainn Bï¿½n
 	}
 	1100.1.1 = {
 		holder = 83143 #Donnchad son of Murchad
 	}
 	1105.1.1 = {
-		holder = 83142 #Conchobar son of Máel Sechlainn Bán
+		holder = 83142 #Conchobar son of Mï¿½el Sechlainn Bï¿½n
 	}
 	1105.7.1 = {
 		holder = 83143 #Donnchad son of Murchad
@@ -280,7 +277,7 @@ c_athlone = {
 		holder = 7194 #Murchad son of Domnall
 	}
 	1115.2.2 = {
-		holder = 83149 #Máel-Sechlainn son of Domnall
+		holder = 83149 #Mï¿½el-Sechlainn son of Domnall
 	}
 	1115.7.1 = {
 		holder = 7194 #Murchad son of Domnall
@@ -301,7 +298,7 @@ c_athlone = {
 		holder = 7194 #Murchad son of Domnall
 	}
 	1153.7.1 = {
-		holder = 7191 #Máel-Sechlainn son of Murchad
+		holder = 7191 #Mï¿½el-Sechlainn son of Murchad
 	}
 	1155.7.1 = {
 		holder = 83156 #Donnchad son of Domnall son of Murchad
@@ -322,10 +319,10 @@ c_athlone = {
 		holder = 7192 #Diarmait son of Domnall son of Murchad
 	}
 	1169.7.1 = {
-		holder = 83153 #Domnall Bregach son of Máel-Sechlainn
+		holder = 83153 #Domnall Bregach son of Mï¿½el-Sechlainn
 	}
 	1173.7.1 = {
-		holder = 83154 #Art son of Máel-Sechlainn
+		holder = 83154 #Art son of Mï¿½el-Sechlainn
 	}
 	1185.1.1 = {
 		liege = "d_meath"
@@ -443,7 +440,7 @@ c_oriel = {
 	1066.1.1 = { change_development_level = 8 }
 	
 	696.1.1 = {
-		holder = 7271 #Fergal son of Máel Duin
+		holder = 7271 #Fergal son of Mï¿½el Duin
 		government = tribal_government
 	}
 	722.12.11 = {
@@ -460,13 +457,13 @@ c_oriel = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	1004.1.1 = {
-		holder = 7253 #Flaithbertach Ua Néill
+		holder = 7253 #Flaithbertach Ua Nï¿½ill
 	}
 	1030.1.1 = {
-		holder = 83073 #Aed mac Flaithbertaig Ua Néill
+		holder = 83073 #Aed mac Flaithbertaig Ua Nï¿½ill
 	}
 	1033.11.30 = {
-		holder = 7253 #Flaithbertach Ua Néill
+		holder = 7253 #Flaithbertach Ua Nï¿½ill
 	}
 	1066.1.1 = {
 		holder = 930
@@ -544,13 +541,13 @@ c_ailech = {
 		holder = 7265 #Aed Uaridnach son of Donall
 	}
 	612.1.1 = {
-		holder = 7267 #Máel Fithrich son of Aed
+		holder = 7267 #Mï¿½el Fithrich son of Aed
 	}
 	630.1.1 = {
-		holder = 7269 #Máel Duin son of Máel Fithrich
+		holder = 7269 #Mï¿½el Duin son of Mï¿½el Fithrich
 	}
 	681.1.1 = {
-		holder = 7271 #Fergal son of Máel Duin
+		holder = 7271 #Fergal son of Mï¿½el Duin
 	}
 	722.12.11 = {
 		holder = 7273 #Niall Frossach
@@ -568,10 +565,10 @@ c_ailech = {
 		holder = 943 #Domnall son of Aed Findliath
 	}
 	915.1.1 = {
-		holder = 131511 #Niall Glúndub son of Aed Findliath
+		holder = 131511 #Niall Glï¿½ndub son of Aed Findliath
 	}
 	919.9.14 = {
-		holder = 131512 #Muirchertach of the Leather Cloaks son of Niall Glúndub
+		holder = 131512 #Muirchertach of the Leather Cloaks son of Niall Glï¿½ndub
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
@@ -631,10 +628,10 @@ c_ailech = {
 		holder = 83110  #Niall son of Muirchertach Mac Lochlainn
 	}
 	1170.7.1 = {
-		holder = 83079  #Aed in Macáem Tóinlesc first Ua Neil since Flaithbertach son of Muirchertach
+		holder = 83079  #Aed in Macï¿½em Tï¿½inlesc first Ua Neil since Flaithbertach son of Muirchertach
 	}
 	1177.7.1 = {
-		holder = 83113 #Máel Sechlainn son of Muirchertach Mac Lochlainn
+		holder = 83113 #Mï¿½el Sechlainn son of Muirchertach Mac Lochlainn
 	}
 	1185.7.1 = {
 		holder = 83108 #Domnall son of Aed Mac Lochlainn
@@ -649,37 +646,37 @@ c_ailech = {
 		holder = 214007 #Muircheartach son Muirchertach Mac Lochlainn
 	}
 	1196.7.1 = {
-		holder = 83080  #Aed Méith
+		holder = 83080  #Aed Mï¿½ith
 	}
 	1201.1.1 = {
 		holder = 83112 #Conchobar Bec son of Conchobar Mac Lochlainn
 	}
 	1201.7.1 = {
-		holder = 83080  #Aed Méith again
+		holder = 83080  #Aed Mï¿½ith again
 	}
 	1230.7.1 = {
-		holder = 83082  #Domnall ÓC mac Aeda Méith
+		holder = 83082  #Domnall ï¿½C mac Aeda Mï¿½ith
 	}
 	1234.7.1 = {
 		holder = 214009  #Domnall son of Muirchertach Mac Lochlainn
 	}
 	1238.7.1 = {
-		holder = 83083  #Brian Ua Néill high-king of Ireland
+		holder = 83083  #Brian Ua Nï¿½ill high-king of Ireland
 	}
 	1260.5.26 = {
-		holder = 83087  #Aed Buide mac Domnaill ÓiC
+		holder = 83087  #Aed Buide mac Domnaill ï¿½iC
 	}
 	1261.7.1 = {
-		holder = 83088  #Niall Cúlánach mac Domnaill ÓiC
+		holder = 83088  #Niall Cï¿½lï¿½nach mac Domnaill ï¿½iC
 	}
 	1263.7.1 = {
-		holder = 83087  #Aed Buide mac Domnaill ÓiC
+		holder = 83087  #Aed Buide mac Domnaill ï¿½iC
 	}
 	1283.7.1 = {
 		holder = 83097  #Domnall mac Briain
 	}
 	1286.7.1 = {
-		holder = 83088  #Niall Cúlánach mac Domnaill ÓiC
+		holder = 83088  #Niall Cï¿½lï¿½nach mac Domnaill ï¿½iC
 	}
 	1290.7.1 = {
 		holder = 83097  #Domnall mac Briain
@@ -691,7 +688,7 @@ c_ailech = {
 		holder = 83097  #Domnall mac Briain
 	}
 	1325.7.1 = {
-		holder = 83091  #Énri mac Aeda Buide
+		holder = 83091  #ï¿½nri mac Aeda Buide
 	}
 	1347.7.1 = {
 		holder = 83102 #Aodh Reamhar
@@ -736,7 +733,7 @@ d_connacht = {
 		holder = 1000 #Aed Ua Ruairc
 	}
 	1087.7.1 = {
-		holder = 911 #Ruaidrí na Saide Buide Ua Conchobair
+		holder = 911 #Ruaidrï¿½ na Saide Buide Ua Conchobair
 	}
 	1092.7.1 = {
 		holder = 83457 #Tadg Ua Conchobair
@@ -754,7 +751,7 @@ d_connacht = {
 		holder = 214520 #Toirrdelbach Ua COncochobair
 	}
 	1156.5.20 = {
-		holder = 214510 #Ruaidrí Ua COncochobair
+		holder = 214510 #Ruaidrï¿½ Ua COncochobair
 	}
 	1183.7.1 = {
 		holder = 0
@@ -769,7 +766,7 @@ c_connacht = {
 		government = tribal_government
 	}
 	649.7.1 = {
-		holder = 83447 #Cenn-Fáelad Ua Briúin Sola
+		holder = 83447 #Cenn-Fï¿½elad Ua Briï¿½in Sola
 	}
 	682.7.1 = {
 		holder = 83406 #Muiredach Muillethan mac Fergusa
@@ -799,7 +796,7 @@ c_connacht = {
 		holder = 83409 #Dub-Indrecht mac Cathail
 	}
 	768.7.1 = {
-		holder = 83403 #Flaithrí mac Domnaill
+		holder = 83403 #Flaithrï¿½ mac Domnaill
 	}
 	777.7.1 = {
 		holder = 83412 #Artgal mac Cathail
@@ -808,7 +805,7 @@ c_connacht = {
 		holder = 83425 #Tipraite mac Taidg
 	}
 	786.7.1 = {
-		holder = 83413 #Cináed m ac Artgail
+		holder = 83413 #Cinï¿½ed m ac Artgail
 	}
 	792.7.1 = {
 		holder = 83404 #Colla mac Fergusa
@@ -817,7 +814,7 @@ c_connacht = {
 		holder = 83393 #Muirgius mac Tommaltaigh
 	}
 	815.7.1 = {
-		holder = 83415 #Máel-Cothaid mac Fagartaig
+		holder = 83415 #Mï¿½el-Cothaid mac Fagartaig
 	}
 	823.7.1 = {
 		holder = 83392 #Diarmait mac Tommaltaigh
@@ -832,13 +829,13 @@ c_connacht = {
 		holder = 83420 #Fergus mac Fothada
 	}
 	843.7.1 = {
-		holder = 83394 #Fínsnechta mac Tommaltaigh
+		holder = 83394 #Fï¿½nsnechta mac Tommaltaigh
 	}
 	848.7.1 = {
-		holder = 83417 #Mugrón mac Maíl COthaid
+		holder = 83417 #Mugrï¿½n mac Maï¿½l COthaid
 	}
 	872.7.1 = {
-		holder = 83382 #Conchobar mac Taidg Móir
+		holder = 83382 #Conchobar mac Taidg Mï¿½ir
 	}
 	882.7.1 = {
 		holder = 83384 #Aed mac Connchobair
@@ -871,28 +868,28 @@ c_connacht = {
 		holder = 910 #Aed in Gai Bernaig
 	}
 	1067.7.1 = {
-		holder = 911 #Ruaidrí na Saide Buide
+		holder = 911 #Ruaidrï¿½ na Saide Buide
 	}
 	1092.7.1 = {
-		holder = 83457 #Tadg mac Ruaidrí
+		holder = 83457 #Tadg mac Ruaidrï¿½
 	}
 	1097.7.1 = {
 		holder = 83119 #Flaithbertach Ua Flaithbertaig
 	}
 	1098.7.1 = {
-		holder = 83458 #Domnall mac Ruaidrí
+		holder = 83458 #Domnall mac Ruaidrï¿½
 	}
 	1106.7.1 = {
-		holder = 214520 #Toirrdelbach mac Ruaidrí
+		holder = 214520 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1156.5.20 = {
-		holder = 214510 #Ruaidrí mac Toirrdelbaig
+		holder = 214510 #Ruaidrï¿½ mac Toirrdelbaig
 	}
 	1183.7.1 = {
 		liege = 0
 	}
 	1183.7.1 = {
-		holder = 214500 #Conchobar Máenmaige mac Ruaidrí
+		holder = 214500 #Conchobar Mï¿½enmaige mac Ruaidrï¿½
 	}
 	1189.7.1 = {
 		holder = 214505 #Cathal Carrach mac Conchobar
@@ -904,19 +901,19 @@ c_connacht = {
 		holder = 83467 #Aed mac Cathail
 	}
 	1225.3.1 = {
-		holder = 214501 #Toirrdelbach mac Ruaidrí
+		holder = 214501 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1225.9.1 = {
 		holder = 83467 #Aed mac Cathail
 	}
 	1228.7.1 = {
-		holder = 214501 #Toirrdelbach mac Ruaidrí
+		holder = 214501 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1230.7.1 = {
 		holder = 83468 #Fedlimid mac Cathail
 	}
 	1231.7.1 = {
-		holder = 214502 #Aed mac Ruaidrí
+		holder = 214502 #Aed mac Ruaidrï¿½
 	}
 	1233.7.1 = {
 		holder = 83468 #Fedlimid mac Cathail
@@ -940,7 +937,7 @@ c_connacht = {
 		holder = 83512 #Aed mac Cathail
 	}
 	1274.5.1 = {
-		holder = 83513 #Eógan mac Ruaidrí
+		holder = 83513 #Eï¿½gan mac Ruaidrï¿½
 	}
 	1274.11.1 = {
 		holder = 83511 #Tadg Ruad mac Toirrdelbaig
@@ -955,22 +952,22 @@ c_connacht = {
 		holder = 83498 #Magnus mac Conchobair Ruaid
 	}
 	1293.7.1 = {
-		holder = 83515 #Aed mac Eógain
+		holder = 83515 #Aed mac Eï¿½gain
 	}
 	1309.7.1 = {
-		holder = 83500 #Aed Bréifnech mac Cathail
+		holder = 83500 #Aed Brï¿½ifnech mac Cathail
 	}
 	1310.7.1 = {
 		holder = 83517 #Fedlimid mac Aeda
 	}
 	1315.7.1 = {
-		holder = 83501 #Ruaidrí mac Cathail Ruaid
+		holder = 83501 #Ruaidrï¿½ mac Cathail Ruaid
 	}
 	1316.2.23 = {
 		holder = 83517 #Fedlimid mac Aeda
 	}
 	1316.9.10 = {
-		holder = 83516 #Ruaidrí na Fed
+		holder = 83516 #Ruaidrï¿½ na Fed
 	}
 	1317.7.1 = {
 		holder = 83519 #Toirrdelbach mac Aeda
@@ -982,7 +979,7 @@ c_connacht = {
 		holder = 83519 #Toirrdelbach mac Aeda
 	}
 	1342.7.1 = {
-		holder = 83502 #Aed son of Aed Bréifnech
+		holder = 83502 #Aed son of Aed Brï¿½ifnech
 	}
 	1343.7.1 = {
 		holder = 83519 #Toirrdelbach mac Aeda
@@ -995,7 +992,7 @@ c_mayo = {
 		government = tribal_government
 	}
 	649.7.1 = {
-		holder = 83447 #Cenn-Fáelad Ua Briúin Sola
+		holder = 83447 #Cenn-Fï¿½elad Ua Briï¿½in Sola
 	}
 	682.7.1 = {
 		holder = 83406 #Muiredach Muillethan mac Fergusa
@@ -1025,7 +1022,7 @@ c_mayo = {
 		holder = 83409 #Dub-Indrecht mac Cathail
 	}
 	768.7.1 = {
-		holder = 83403 #Flaithrí mac Domnaill
+		holder = 83403 #Flaithrï¿½ mac Domnaill
 	}
 	777.7.1 = {
 		holder = 83412 #Artgal mac Cathail
@@ -1034,7 +1031,7 @@ c_mayo = {
 		holder = 83425 #Tipraite mac Taidg
 	}
 	786.7.1 = {
-		holder = 83413 #Cináed m ac Artgail
+		holder = 83413 #Cinï¿½ed m ac Artgail
 	}
 	792.7.1 = {
 		holder = 83404 #Colla mac Fergusa
@@ -1043,7 +1040,7 @@ c_mayo = {
 		holder = 83393 #Muirgius mac Tommaltaigh
 	}
 	815.7.1 = {
-		holder = 83415 #Máel-Cothaid mac Fagartaig
+		holder = 83415 #Mï¿½el-Cothaid mac Fagartaig
 	}
 	823.7.1 = {
 		holder = 83392 #Diarmait mac Tommaltaigh
@@ -1058,13 +1055,13 @@ c_mayo = {
 		holder = 83420 #Fergus mac Fothada
 	}
 	843.7.1 = {
-		holder = 83394 #Fínsnechta mac Tommaltaigh
+		holder = 83394 #Fï¿½nsnechta mac Tommaltaigh
 	}
 	848.7.1 = {
-		holder = 83417 #Mugrón mac Maíl COthaid
+		holder = 83417 #Mugrï¿½n mac Maï¿½l COthaid
 	}
 	872.7.1 = {
-		holder = 83382 #Conchobar mac Taidg Móir
+		holder = 83382 #Conchobar mac Taidg Mï¿½ir
 	}
 	882.7.1 = {
 		holder = 83384 #Aed mac Connchobair
@@ -1097,28 +1094,28 @@ c_mayo = {
 		holder = 910 #Aed in Gai Bernaig
 	}
 	1067.7.1 = {
-		holder = 911 #Ruaidrí na Saide Buide
+		holder = 911 #Ruaidrï¿½ na Saide Buide
 	}
 	1092.7.1 = {
-		holder = 83457 #Tadg mac Ruaidrí
+		holder = 83457 #Tadg mac Ruaidrï¿½
 	}
 	1097.7.1 = {
 		holder = 83119 #Flaithbertach Ua Flaithbertaig
 	}
 	1098.7.1 = {
-		holder = 83458 #Domnall mac Ruaidrí
+		holder = 83458 #Domnall mac Ruaidrï¿½
 	}
 	1106.7.1 = {
-		holder = 214520 #Toirrdelbach mac Ruaidrí
+		holder = 214520 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1156.5.20 = {
-		holder = 214510 #Ruaidrí mac Toirrdelbaig
+		holder = 214510 #Ruaidrï¿½ mac Toirrdelbaig
 	}
 	1183.7.1 = {
 		liege = 0
 	}
 	1183.7.1 = {
-		holder = 214500 #Conchobar Máenmaige mac Ruaidrí
+		holder = 214500 #Conchobar Mï¿½enmaige mac Ruaidrï¿½
 	}
 	1189.7.1 = {
 		holder = 214505 #Cathal Carrach mac Conchobar
@@ -1130,19 +1127,19 @@ c_mayo = {
 		holder = 83467 #Aed mac Cathail
 	}
 	1225.3.1 = {
-		holder = 214501 #Toirrdelbach mac Ruaidrí
+		holder = 214501 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1225.9.1 = {
 		holder = 83467 #Aed mac Cathail
 	}
 	1228.7.1 = {
-		holder = 214501 #Toirrdelbach mac Ruaidrí
+		holder = 214501 #Toirrdelbach mac Ruaidrï¿½
 	}
 	1230.7.1 = {
 		holder = 83468 #Fedlimid mac Cathail
 	}
 	1231.7.1 = {
-		holder = 214502 #Aed mac Ruaidrí
+		holder = 214502 #Aed mac Ruaidrï¿½
 	}
 	1233.7.1 = {
 		holder = 83468 #Fedlimid mac Cathail
@@ -1166,7 +1163,7 @@ c_mayo = {
 		holder = 83512 #Aed mac Cathail
 	}
 	1274.5.1 = {
-		holder = 83513 #Eógan mac Ruaidrí
+		holder = 83513 #Eï¿½gan mac Ruaidrï¿½
 	}
 	1274.11.1 = {
 		holder = 83511 #Tadg Ruad mac Toirrdelbaig
@@ -1181,22 +1178,22 @@ c_mayo = {
 		holder = 83498 #Magnus mac Conchobair Ruaid
 	}
 	1293.7.1 = {
-		holder = 83515 #Aed mac Eógain
+		holder = 83515 #Aed mac Eï¿½gain
 	}
 	1309.7.1 = {
-		holder = 83500 #Aed Bréifnech mac Cathail
+		holder = 83500 #Aed Brï¿½ifnech mac Cathail
 	}
 	1310.7.1 = {
 		holder = 83517 #Fedlimid mac Aeda
 	}
 	1315.7.1 = {
-		holder = 83501 #Ruaidrí mac Cathail Ruaid
+		holder = 83501 #Ruaidrï¿½ mac Cathail Ruaid
 	}
 	1316.2.23 = {
 		holder = 83517 #Fedlimid mac Aeda
 	}
 	1316.9.10 = {
-		holder = 83516 #Ruaidrí na Fed
+		holder = 83516 #Ruaidrï¿½ na Fed
 	}
 	1317.7.1 = {
 		holder = 83519 #Toirrdelbach mac Aeda
@@ -1208,7 +1205,7 @@ c_mayo = {
 		holder = 83519 #Toirrdelbach mac Aeda
 	}
 	1342.7.1 = {
-		holder = 83502 #Aed son of Aed Bréifnech
+		holder = 83502 #Aed son of Aed Brï¿½ifnech
 	}
 	1343.7.1 = {
 		holder = 83519 #Toirrdelbach mac Aeda
@@ -1221,13 +1218,13 @@ c_breifne = {
 		government = tribal_government
 	}
 	850.1.1 = {
-		holder = 83533 #Tigernán Ua Briúin
+		holder = 83533 #Tigernï¿½n Ua Briï¿½in
 	}
 	892.7.1 = {
-		holder = 83534 #Ruarc mac Tigernáin Ua Briúin
+		holder = 83534 #Ruarc mac Tigernï¿½in Ua Briï¿½in
 	}
 	898.7.1 = {
-		holder = 83535 #Art mac Ruairc Ua Briúin
+		holder = 83535 #Art mac Ruairc Ua Briï¿½in
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
@@ -1248,10 +1245,10 @@ c_breifne = {
 		liege = "d_connacht"
 	}
 	1087.7.1 = {
-		holder = 1003 #Tigernán mac Ualgairg
+		holder = 1003 #Tigernï¿½n mac Ualgairg
 	}
 	1091.7.1 = {
-		holder = 1004 #Domnall mac Tigernáin
+		holder = 1004 #Domnall mac Tigernï¿½in
 	}
 	1102.7.1 = {
 		holder = 7287 #Domnall mac Ualgairg
@@ -1260,16 +1257,16 @@ c_breifne = {
 		holder = 214024 #Aed son of Domnall mac Ualgairg
 	}
 	1122.7.1 = {
-		holder = 83549 #Gilla-Braite son of Domnall mac Tigernáin
+		holder = 83549 #Gilla-Braite son of Domnall mac Tigernï¿½in
 	}
 	1125.7.1 = {
-		holder = 214022 #Tigernán Mór mac Aeda
+		holder = 214022 #Tigernï¿½n Mï¿½r mac Aeda
 	}
 	1152.3.1 = {
 		holder = 83550 #Aed son of Gilla-Braite
 	}
 	1152.9.1 = {
-		holder = 214022 #Tigernán Mór mac Aeda
+		holder = 214022 #Tigernï¿½n Mï¿½r mac Aeda
 	}
 	1172.1.1 = {
 		liege = 0
@@ -1278,7 +1275,7 @@ c_breifne = {
 		holder = 83550 #Aed son of Gilla-Braite
 	}
 	1176.7.1 = {
-		holder = 83555 #Amlaíb mac Fergaile
+		holder = 83555 #Amlaï¿½b mac Fergaile
 	}
 	1184.7.1 = {
 		holder = 214027 #Ualgarg mac Cathail
@@ -1293,37 +1290,37 @@ c_breifne = {
 		holder = 83552 #Cathal Riabach
 	}
 	1236.7.1 = {
-		holder = 83544 #Conchobar son of Tigernán
+		holder = 83544 #Conchobar son of Tigernï¿½n
 	}
 	1256.7.1 = {
 		holder = 83562 #Sihtric son of Ualgarg
 	}
 	1257.7.1 = {
-		holder = 83562 #Amlaíb son of Art son of Domnall
+		holder = 83562 #Amlaï¿½b son of Art son of Domnall
 	}
 	1258.7.1 = {
-		holder = 83545 #Domnall son of Conchobar son of Tigernán
+		holder = 83545 #Domnall son of Conchobar son of Tigernï¿½n
 	}
 	1258.11.1 = {
 		holder = 83553 #Art son of Cathal Riabach
 	}
 	1259.7.1 = {
-		holder = 83545 #Domnall son of Conchobar son of Tigernán
+		holder = 83545 #Domnall son of Conchobar son of Tigernï¿½n
 	}
 	1260.7.1 = {
 		holder = 83553 #Art son of Cathal Riabach
 	}
 	1266.7.1 = {
-		holder = 83566 #Conchobar Buide mac Amlaíb
+		holder = 83566 #Conchobar Buide mac Amlaï¿½b
 	}
 	1273.7.1 = {
-		holder = 83542 #Tigernán mac Aéda
+		holder = 83542 #Tigernï¿½n mac Aï¿½da
 	}
 	1274.7.1 = {
-		holder = 83554 #Amlaíb mac Airt
+		holder = 83554 #Amlaï¿½b mac Airt
 	}
 	1307.7.1 = {
-		holder = 454161 #Domnall Carrach mac Amlaíb
+		holder = 454161 #Domnall Carrach mac Amlaï¿½b
 	}
 	1311.7.1 = {
 		holder = 454160 #Ualgarg mac Domnaill Charraigh
@@ -1355,26 +1352,26 @@ d_leinster = {
 
 c_leinster = {
 	430.1.1 = {
-		holder = 83160 #Énna Cennsalach
+		holder = 83160 #ï¿½nna Cennsalach
 		government = tribal_government
 	}
 	450.7.1 = {
-		holder = 83161 #Crimthann son of Énna Cennsalach
+		holder = 83161 #Crimthann son of ï¿½nna Cennsalach
 	}
 	483.7.1 = {
-		holder = 83173 #Nath Í son of Crimthann
+		holder = 83173 #Nath ï¿½ son of Crimthann
 	}
 	512.7.1 = {
-		holder = 83173 #Óengus son of Feidlimid FIX
+		holder = 83173 #ï¿½engus son of Feidlimid FIX
 	}
 	522.7.1 = {
-		holder = 83164 #Eógan Cáech
+		holder = 83164 #Eï¿½gan Cï¿½ech
 	}
 	540.7.1 = {
-		holder = 83174  #Muiredach son of Óengus
+		holder = 83174  #Muiredach son of ï¿½engus
 	}
 	544.7.1 = {
-		holder = 83180  #Fáelán son of Sílán
+		holder = 83180  #Fï¿½elï¿½n son of Sï¿½lï¿½n
 	}
 	589.7.1 = {
 		holder = 83175  #Echu son of Muiredach
@@ -1383,19 +1380,19 @@ c_leinster = {
 		holder = 83176  #Brandub son of Echu
 	}
 	608.7.1 = {
-		holder = 83166  #Rónán son of Colmán
+		holder = 83166  #Rï¿½nï¿½n son of Colmï¿½n
 	}
 	624.7.1 = {
-		holder = 83167  #Crundmáel son of Rónán
+		holder = 83167  #Crundmï¿½el son of Rï¿½nï¿½n
 	}
 	644.7.1 = {
-		holder = 83182  #Élothach son of Fáelchú
+		holder = 83182  #ï¿½lothach son of Fï¿½elchï¿½
 	}
 	728.7.1 = {
-		holder = 83171  #Aed Ua Cheinnselaig son of Colcú
+		holder = 83171  #Aed Ua Cheinnselaig son of Colcï¿½
 	}
 	738.7.1 = {
-		holder = 217321 #Sechnusach au Cheinnselaig son of Colcú # assumed successor
+		holder = 217321 #Sechnusach au Cheinnselaig son of Colcï¿½ # assumed successor
 	}
 	747.4.1 = {
 		holder = 217322 #Forbasach au Cheinnselaig son of Sechnusach # assumed successor
@@ -1410,7 +1407,7 @@ c_leinster = {
 		holder = 166100 #Murchad mac Finn
 	}
 	1003.1.1 = {
-		holder = 166101 #Máel Mórda mac Murchada
+		holder = 166101 #Mï¿½el Mï¿½rda mac Murchada
 	}
 	1042.7.1 = {
 		holder = 922 #Diarmait son of Donnchad
@@ -1422,19 +1419,19 @@ c_leinster = {
 		holder = 920 #Donnchad son of Domnall Remar
 	}
 	1089.7.1 = {
-		holder = 923 #Énna son of Diarmait
+		holder = 923 #ï¿½nna son of Diarmait
 	}
 	1092.7.1 = {
-		holder = 83188 #Diarmait son of Énna
+		holder = 83188 #Diarmait son of ï¿½nna
 	}
 	1098.7.1 = {
 		holder = 6166 #Donnchad son of Murchad
 	}
 	1115.7.1 = {
-		holder = 83191 #Diarmait son of Énna
+		holder = 83191 #Diarmait son of ï¿½nna
 	}
 	1117.7.1 = {
-		holder = 83192 #Énna son of Donnchad
+		holder = 83192 #ï¿½nna son of Donnchad
 	}
 	1126.7.1 = {
 		holder = 214550 #Diarmait son of Donnchad
@@ -1449,7 +1446,7 @@ c_leinster = {
 		liege = "d_leinster"
 	}
 	1171.5.1 = {
-		holder = 214555 #Domnall Cáemánach
+		holder = 214555 #Domnall Cï¿½emï¿½nach
 	}
 	1175.7.1 = {
 		holder = 83200 #Muirchertach Mac Murchada-Cennselach
@@ -1458,7 +1455,7 @@ c_leinster = {
 		liege = "d_meath"
 	}
 	1193.7.1 = {
-		holder = 83195 #Domnall son of Domnall Cáemánach
+		holder = 83195 #Domnall son of Domnall Cï¿½emï¿½nach
 	}
 	1250.7.1 = {
 		holder = 83196 #Muirchertach son of Domnall
@@ -1482,34 +1479,34 @@ c_ossory = {
 		government = tribal_government
 	}
 	581.1.1 = {
-		holder = 166002 #Colmán mac Feradaig
+		holder = 166002 #Colmï¿½n mac Feradaig
 	}
 	603.1.1 = {
-		holder = 166003 #Crundmaíl mac Colmán
+		holder = 166003 #Crundmaï¿½l mac Colmï¿½n
 	}
 	635.1.1 = {
-		holder = 166004 #Scannlan Mór mac Colmán
+		holder = 166004 #Scannlan Mï¿½r mac Colmï¿½n
 	}
 	644.1.1 = {
-		holder = 166005 #Fáelán mac Crundmaíl
+		holder = 166005 #Fï¿½elï¿½n mac Crundmaï¿½l
 	}
 	660.1.1 = {
-		holder = 166006 #Tuaim Snámha mac Crundmaíl
+		holder = 166006 #Tuaim Snï¿½mha mac Crundmaï¿½l
 	}
 	678.1.1 = {
-		holder = 166010 #Fáelchar mac Forandla
+		holder = 166010 #Fï¿½elchar mac Forandla
 	}
 	693.1.1 = {
-		holder = 166011 #Cú Cherca mac Fáeláin
+		holder = 166011 #Cï¿½ Cherca mac Fï¿½elï¿½in
 	}
 	712.1.1 = {
 		holder = 166012 #Fland mac Congaile
 	}
 	717.1.1 = {
-		holder = 166013 #Ailill mac Fáeláin
+		holder = 166013 #Ailill mac Fï¿½elï¿½in
 	}
 	724.1.1 = {
-		holder = 166014 #Cellach mac Fáelchair
+		holder = 166014 #Cellach mac Fï¿½elchair
 	}
 	735.1.1 = {
 		holder = 166015 #Forbasach mac Ailella
@@ -1518,28 +1515,28 @@ c_ossory = {
 		holder = 166016 #Anmchad mac Con Cherca
 	}
 	761.1.1 = {
-		holder = 166017 #Tóim Snáma mac Flainn
+		holder = 166017 #Tï¿½im Snï¿½ma mac Flainn
 	}
 	770.1.1 = {
-		holder = 166018 #Dúngal mac Cellaig
+		holder = 166018 #Dï¿½ngal mac Cellaig
 	}
 	772.1.1 = {
-		holder = 166020 #Fáelán mac Forbasaig
+		holder = 166020 #Fï¿½elï¿½n mac Forbasaig
 	}
 	786.1.1 = {
-		holder = 166021 #Máel Dúin mac Cummascaig
+		holder = 166021 #Mï¿½el Dï¿½in mac Cummascaig
 	}
 	797.1.1 = {
 		holder = 166022 #Fergal mac Anmchada
 	}
 	802.1.1 = {
-		holder = 166023 #Dúngal mac Fergaile
+		holder = 166023 #Dï¿½ngal mac Fergaile
 	}
 	842.1.1 = {
-		holder = 166024 #Cerball mac Dúnlainge
+		holder = 166024 #Cerball mac Dï¿½nlainge
 	}
 	888.1.1 = {
-		holder = 166025 #Riacan mac Dúnlainge
+		holder = 166025 #Riacan mac Dï¿½nlainge
 	}
 	894.1.1 = {
 		holder = 166030 #Diarmait mac Cerbaill
@@ -1557,25 +1554,25 @@ c_ossory = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	976.7.1 = {
-		holder = 83210 #Gilla-Pátraic son of Donnchad son of Cellach
+		holder = 83210 #Gilla-Pï¿½traic son of Donnchad son of Cellach
 	}
 	996.7.1 = {
-		holder = 83212 #Donnchad son of Gilla-Pátraic
+		holder = 83212 #Donnchad son of Gilla-Pï¿½traic
 	}
 	1039.7.1 = {
-		holder = 83211 #Muirchertach son of Gilla-Pátraic
+		holder = 83211 #Muirchertach son of Gilla-Pï¿½traic
 	}
 	1041.7.1 = {
-		holder = 83213 #Gilla-Pátraic son of Donnchad
+		holder = 83213 #Gilla-Pï¿½traic son of Donnchad
 	}
 	1055.7.1 = {
-		holder = 1020 #Domnall son of Gilla-Pátraic
+		holder = 1020 #Domnall son of Gilla-Pï¿½traic
 	}
 	1080.7.1 = {
 		holder = 1022 #Donnchad son of Domnall
 	}
 	1090.7.1 = {
-		holder = 83220 #Gilla-Pátraic Ruad
+		holder = 83220 #Gilla-Pï¿½traic Ruad
 	}
 	1103.7.1 = {
 		holder = 83222 #Cerball
@@ -1596,7 +1593,7 @@ c_ossory = {
 		holder = 83223 #Conchobar son of Cerball
 	}
 	1126.7.1 = {
-		holder = 83215 #Gilla-Pátraic son of Domnall
+		holder = 83215 #Gilla-Pï¿½traic son of Domnall
 	}
 	1146.7.1 = {
 		holder = 83216 #Cerball son of Domnall
@@ -1663,7 +1660,7 @@ c_ossory = {
 
 d_munster = {
 	978.7.1 = {
-		holder = 900 #Brian Bóruma mac Cennétig
+		holder = 900 #Brian Bï¿½ruma mac Cennï¿½tig
 	}
 	1014.4.23 = {
 		holder = 0
@@ -1728,10 +1725,10 @@ c_thomond = {
 		holder = 83736 #Crimthann son of Ailill
 	}
 	492.1.1 = {
-		holder = 83610 #Eochaid son of Óengus son of Nad Froich
+		holder = 83610 #Eochaid son of ï¿½engus son of Nad Froich
 	}
 	520.1.1 = {
-		holder = 83737 #Éndae son of Crimthann
+		holder = 83737 #ï¿½ndae son of Crimthann
 	}
 	551.1.1 = {
 		holder = 83616 #Crimthann grandson of Eochaid
@@ -1740,11 +1737,11 @@ c_thomond = {
 		holder = 83765 #Coirpre Cromm son of Crimthann
 	}
 	580.1.1 = {
-		holder = 83738 #Amalgaid son of Éndae
+		holder = 83738 #Amalgaid son of ï¿½ndae
 	}
 	
 	590.1.1 = {
-		holder = 83739 #Garbán son of Éndae
+		holder = 83739 #Garbï¿½n son of ï¿½ndae
 	}
 	594.1.1 = {
 		holder = 83767 #Feidlimid son of Coirpre Cromm
@@ -1753,76 +1750,76 @@ c_thomond = {
 		holder = 83768 #Cathal son of Aed Fland
 	}
 	628.1.1 = {
-		holder = 83740 #Cúán son of Amalgaid
+		holder = 83740 #Cï¿½ï¿½n son of Amalgaid
 	}
 	641.1.1 = {
-		holder = 83769 #Cathal Cú-Cen-Máthair son of Cathal son of Aed Fland
+		holder = 83769 #Cathal Cï¿½-Cen-Mï¿½thair son of Cathal son of Aed Fland
 	}
 	679.1.1 = {
-		holder = 83770 #Finguine son of Cathal Cú-Cen-Máthair
+		holder = 83770 #Finguine son of Cathal Cï¿½-Cen-Mï¿½thair
 	}
 	696.1.1 = {
-		holder = 83771 #Ailill son of Cathal Cú-Cen-Máthair
+		holder = 83771 #Ailill son of Cathal Cï¿½-Cen-Mï¿½thair
 	}
 	701.1.1 = {
-		holder = 83743 #Eterscél son of Máel-Umai
+		holder = 83743 #Eterscï¿½l son of Mï¿½el-Umai
 	}
 	721.1.1 = {
-		holder = 83744 #Cathussach son of Eterscél
+		holder = 83744 #Cathussach son of Eterscï¿½l
 	}
 	733.1.1 = {
 		holder = 83772 #Cathal son of Finguine
 	}
 	742.1.1 = {
-		holder = 83789 #Máel-Dúin son of Aed of the Eóganactha Locha Léin
+		holder = 83789 #Mï¿½el-Dï¿½in son of Aed of the Eï¿½ganactha Locha Lï¿½in
 	}
 	786.1.1 = {
-		holder = 83746 #Ólchobar son of Dub-Indrecht
+		holder = 83746 #ï¿½lchobar son of Dub-Indrecht
 	}
 	793.1.1 = {
-		holder = 83773 #Artrí son of Cathal
+		holder = 83773 #Artrï¿½ son of Cathal
 	}
 	821.1.1 = {
-		holder = 83793 #Ólchobar son of Cináed
+		holder = 83793 #ï¿½lchobar son of Cinï¿½ed
 	}
 	851.1.1 = {
-		holder = 83774 #Tuathal son of Artrí
+		holder = 83774 #Tuathal son of Artrï¿½
 	}
 	861.1.1 = {
-		holder = 83763 #Cenn-Fáelad Ua Mugthigirn son of Murchad
+		holder = 83763 #Cenn-Fï¿½elad Ua Mugthigirn son of Murchad
 	}
 	872.1.1 = {
-		holder = 83672 #Dúnchad son of Dub-dá-Bairenn
+		holder = 83672 #Dï¿½nchad son of Dub-dï¿½-Bairenn
 	}
 	888.1.1 = {
-		holder = 83659 #Dub-Lachtna son of Máel-Gualae
+		holder = 83659 #Dub-Lachtna son of Mï¿½el-Gualae
 	}
 	895.1.1 = {
-		holder = 83675 #Finguine Cenn nGécán son of Láegaire
+		holder = 83675 #Finguine Cenn nGï¿½cï¿½n son of Lï¿½egaire
 	}
 	902.1.1 = {
-		holder = 83692 #Lorcán son Condlígan
+		holder = 83692 #Lorcï¿½n son Condlï¿½gan
 	}
 	922.1.1 = {
-		holder = 83666 #Cellachán Caisil son of Buadachán
+		holder = 83666 #Cellachï¿½n Caisil son of Buadachï¿½n
 	}
 	930.1.1 = {
-		holder = 83330 #Cennétig of Dál Cais
+		holder = 83330 #Cennï¿½tig of Dï¿½l Cais
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	951.7.1 = {
-		holder = 83332 #Mathgamain mac Cennétig
+		holder = 83332 #Mathgamain mac Cennï¿½tig
 	}
 	976.7.1 = {
-		holder = 900 #Brian Bóruma mac Cennétig
+		holder = 900 #Brian Bï¿½ruma mac Cennï¿½tig
 	}
 	978.7.1 = {
 		liege = "d_munster"
 	}
 	1014.4.23 = {
-		holder = 83647 #Dúngal son of Máel-Fothardaig
+		holder = 83647 #Dï¿½ngal son of Mï¿½el-Fothardaig
 	}
 	1024.7.1 = {
 		holder = 902 #Donnchad mac Briain
@@ -1861,7 +1858,7 @@ c_thomond = {
 		holder = 214590 #Toirrdellbach mac Diarmata
 	}
 	1152.7.1 = {
-		holder = 83334 #Tadg Gláe mac Diarmata
+		holder = 83334 #Tadg Glï¿½e mac Diarmata
 	}
 	1154.7.1 = {
 		holder = 214590 #Toirrdellbach mac Diarmata
@@ -1870,7 +1867,7 @@ c_thomond = {
 		holder = 83336 #Muirchertach son of Toirrdellbach mac Diarmata
 	}
 	1168.7.1 = {
-		holder = 214580 #Domnall Mór son of Toirrdellbach mac Diarmata
+		holder = 214580 #Domnall Mï¿½r son of Toirrdellbach mac Diarmata
 	}
 	1172.1.1 = {
 		liege = "k_england"
@@ -1879,10 +1876,10 @@ c_thomond = {
 		liege = "d_meath"
 	}
 	1194.7.1 = {
-		holder = 214582 #Conchobar Ruad mac Domnaill Móír
+		holder = 214582 #Conchobar Ruad mac Domnaill Mï¿½ï¿½r
 	}
 	1203.7.1 = {
-		holder = 214583 #Donnchad Caiprech mac Domnaill Móír
+		holder = 214583 #Donnchad Caiprech mac Domnaill Mï¿½ï¿½r
 	}
 	1242.7.1 = {
 		holder = 83340 #Conchobar na Siudaine
@@ -1894,13 +1891,13 @@ c_thomond = {
 		holder = 83344 #Donnchad mac Briain Ruaid
 	}
 	1284.7.1 = {
-		holder = 454140 #Toirrdelbach son of Tadg of Cáenluisce
+		holder = 454140 #Toirrdelbach son of Tadg of Cï¿½enluisce
 	}
 	1306.8.1 = {
 		holder = 83351 #Donnchad son of Toirrdelbach
 	}
 	1311.7.1 = {
-		holder = 83347 #Diarmait Cléirech mac Donnchada
+		holder = 83347 #Diarmait Clï¿½irech mac Donnchada
 	}
 	1311.7.1 = {
 		liege = 0
@@ -1912,7 +1909,7 @@ c_thomond = {
 		holder = 454205 #Muirchertach son of Toirrdelbach
 	}
 	1343.7.1 = {
-		holder = 83349 #Brian Bán mac Domnaill
+		holder = 83349 #Brian Bï¿½n mac Domnaill
 	}
 }
 
@@ -1931,10 +1928,10 @@ c_ennis = {
 		holder = 83736 #Crimthann son of Ailill
 	}
 	492.1.1 = {
-		holder = 83610 #Eochaid son of Óengus son of Nad Froich
+		holder = 83610 #Eochaid son of ï¿½engus son of Nad Froich
 	}
 	520.1.1 = {
-		holder = 83737 #Éndae son of Crimthann
+		holder = 83737 #ï¿½ndae son of Crimthann
 	}
 	551.1.1 = {
 		holder = 83616 #Crimthann grandson of Eochaid
@@ -1943,11 +1940,11 @@ c_ennis = {
 		holder = 83765 #Coirpre Cromm son of Crimthann
 	}
 	580.1.1 = {
-		holder = 83738 #Amalgaid son of Éndae
+		holder = 83738 #Amalgaid son of ï¿½ndae
 	}
 	
 	590.1.1 = {
-		holder = 83739 #Garbán son of Éndae
+		holder = 83739 #Garbï¿½n son of ï¿½ndae
 	}
 	594.1.1 = {
 		holder = 83767 #Feidlimid son of Coirpre Cromm
@@ -1956,76 +1953,76 @@ c_ennis = {
 		holder = 83768 #Cathal son of Aed Fland
 	}
 	628.1.1 = {
-		holder = 83740 #Cúán son of Amalgaid
+		holder = 83740 #Cï¿½ï¿½n son of Amalgaid
 	}
 	641.1.1 = {
-		holder = 83769 #Cathal Cú-Cen-Máthair son of Cathal son of Aed Fland
+		holder = 83769 #Cathal Cï¿½-Cen-Mï¿½thair son of Cathal son of Aed Fland
 	}
 	679.1.1 = {
-		holder = 83770 #Finguine son of Cathal Cú-Cen-Máthair
+		holder = 83770 #Finguine son of Cathal Cï¿½-Cen-Mï¿½thair
 	}
 	696.1.1 = {
-		holder = 83771 #Ailill son of Cathal Cú-Cen-Máthair
+		holder = 83771 #Ailill son of Cathal Cï¿½-Cen-Mï¿½thair
 	}
 	701.1.1 = {
-		holder = 83743 #Eterscél son of Máel-Umai
+		holder = 83743 #Eterscï¿½l son of Mï¿½el-Umai
 	}
 	721.1.1 = {
-		holder = 83744 #Cathussach son of Eterscél
+		holder = 83744 #Cathussach son of Eterscï¿½l
 	}
 	733.1.1 = {
 		holder = 83772 #Cathal son of Finguine
 	}
 	742.1.1 = {
-		holder = 83789 #Máel-Dúin son of Aed of the Eóganactha Locha Léin
+		holder = 83789 #Mï¿½el-Dï¿½in son of Aed of the Eï¿½ganactha Locha Lï¿½in
 	}
 	786.1.1 = {
-		holder = 83746 #Ólchobar son of Dub-Indrecht
+		holder = 83746 #ï¿½lchobar son of Dub-Indrecht
 	}
 	793.1.1 = {
-		holder = 83773 #Artrí son of Cathal
+		holder = 83773 #Artrï¿½ son of Cathal
 	}
 	821.1.1 = {
-		holder = 83793 #Ólchobar son of Cináed
+		holder = 83793 #ï¿½lchobar son of Cinï¿½ed
 	}
 	851.1.1 = {
-		holder = 83774 #Tuathal son of Artrí
+		holder = 83774 #Tuathal son of Artrï¿½
 	}
 	861.1.1 = {
-		holder = 83763 #Cenn-Fáelad Ua Mugthigirn son of Murchad
+		holder = 83763 #Cenn-Fï¿½elad Ua Mugthigirn son of Murchad
 	}
 	872.1.1 = {
-		holder = 83672 #Dúnchad son of Dub-dá-Bairenn
+		holder = 83672 #Dï¿½nchad son of Dub-dï¿½-Bairenn
 	}
 	888.1.1 = {
-		holder = 83659 #Dub-Lachtna son of Máel-Gualae
+		holder = 83659 #Dub-Lachtna son of Mï¿½el-Gualae
 	}
 	895.1.1 = {
-		holder = 83675 #Finguine Cenn nGécán son of Láegaire
+		holder = 83675 #Finguine Cenn nGï¿½cï¿½n son of Lï¿½egaire
 	}
 	902.1.1 = {
-		holder = 83692 #Lorcán son Condlígan
+		holder = 83692 #Lorcï¿½n son Condlï¿½gan
 	}
 	922.1.1 = {
-		holder = 83666 #Cellachán Caisil son of Buadachán
+		holder = 83666 #Cellachï¿½n Caisil son of Buadachï¿½n
 	}
 	930.1.1 = {
-		holder = 83330 #Cennétig of Dál Cais
+		holder = 83330 #Cennï¿½tig of Dï¿½l Cais
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	951.7.1 = {
-		holder = 83332 #Mathgamain mac Cennétig
+		holder = 83332 #Mathgamain mac Cennï¿½tig
 	}
 	976.7.1 = {
-		holder = 900 #Brian Bóruma mac Cennétig
+		holder = 900 #Brian Bï¿½ruma mac Cennï¿½tig
 	}
 	978.7.1 = {
 		liege = "d_munster"
 	}
 	1014.4.23 = {
-		holder = 83647 #Dúngal son of Máel-Fothardaig
+		holder = 83647 #Dï¿½ngal son of Mï¿½el-Fothardaig
 	}
 	1024.7.1 = {
 		holder = 902 #Donnchad mac Briain
@@ -2064,7 +2061,7 @@ c_ennis = {
 		holder = 214590 #Toirrdellbach mac Diarmata
 	}
 	1152.7.1 = {
-		holder = 83334 #Tadg Gláe mac Diarmata
+		holder = 83334 #Tadg Glï¿½e mac Diarmata
 	}
 	1154.7.1 = {
 		holder = 214590 #Toirrdellbach mac Diarmata
@@ -2073,7 +2070,7 @@ c_ennis = {
 		holder = 83336 #Muirchertach son of Toirrdellbach mac Diarmata
 	}
 	1168.7.1 = {
-		holder = 214580 #Domnall Mór son of Toirrdellbach mac Diarmata
+		holder = 214580 #Domnall Mï¿½r son of Toirrdellbach mac Diarmata
 	}
 	1172.1.1 = {
 		liege = "k_england"
@@ -2082,10 +2079,10 @@ c_ennis = {
 		liege = "d_meath"
 	}
 	1194.7.1 = {
-		holder = 214582 #Conchobar Ruad mac Domnaill Móír
+		holder = 214582 #Conchobar Ruad mac Domnaill Mï¿½ï¿½r
 	}
 	1203.7.1 = {
-		holder = 214583 #Donnchad Caiprech mac Domnaill Móír
+		holder = 214583 #Donnchad Caiprech mac Domnaill Mï¿½ï¿½r
 	}
 	1242.7.1 = {
 		holder = 83340 #Conchobar na Siudaine
@@ -2097,13 +2094,13 @@ c_ennis = {
 		holder = 83344 #Donnchad mac Briain Ruaid
 	}
 	1284.7.1 = {
-		holder = 454140 #Toirrdelbach son of Tadg of Cáenluisce
+		holder = 454140 #Toirrdelbach son of Tadg of Cï¿½enluisce
 	}
 	1306.8.1 = {
 		holder = 83351 #Donnchad son of Toirrdelbach
 	}
 	1311.7.1 = {
-		holder = 83347 #Diarmait Cléirech mac Donnchada
+		holder = 83347 #Diarmait Clï¿½irech mac Donnchada
 	}
 	1311.7.1 = {
 		liege = 0
@@ -2115,7 +2112,7 @@ c_ennis = {
 		holder = 454205 #Muirchertach son of Toirrdelbach
 	}
 	1343.7.1 = {
-		holder = 83349 #Brian Bán mac Domnaill
+		holder = 83349 #Brian Bï¿½n mac Domnaill
 	}
 }
 
@@ -2129,13 +2126,13 @@ c_ormond = {
 		holder = 83608 #Nad Froich son of Conall
 	}
 	450.1.1 = {
-		holder = 83609 #Óengus son of Nad Froich
+		holder = 83609 #ï¿½engus son of Nad Froich
 	}
 	492.1.1 = {
-		holder = 83611 #Feidelmid son of Óengus son of Nad Froich
+		holder = 83611 #Feidelmid son of ï¿½engus son of Nad Froich
 	}
 	533.1.1 = {
-		holder = 83612 #Bressal son of Óengus son of Nad Froich
+		holder = 83612 #Bressal son of ï¿½engus son of Nad Froich
 	}
 	544.1.1 = {
 		holder = 83617 #Crimthann son of Feidelmid
@@ -2144,70 +2141,70 @@ c_ormond = {
 		holder = 83618 #Aed Dub son of Crimthann
 	}
 	600.1.1 = {
-		holder = 83619 #Fíngen son of Aed Dub
+		holder = 83619 #Fï¿½ngen son of Aed Dub
 	}
 	619.1.1 = {
-		holder = 83620 #Faílbe Fland son of Aed Dub
+		holder = 83620 #Faï¿½lbe Fland son of Aed Dub
 	}
 	639.1.1 = {
-		holder = 83621 #Máenach son of Fíngen
+		holder = 83621 #Mï¿½enach son of Fï¿½ngen
 	}
 	662.1.1 = {
-		holder = 83628 #Colgú son of Faílbe Fland
+		holder = 83628 #Colgï¿½ son of Faï¿½lbe Fland
 	}
 	678.1.1 = {
-		holder = 83626 #Tnúthgal son of Fogartach
+		holder = 83626 #Tnï¿½thgal son of Fogartach
 	}
 	701.1.1 = {
 		holder = 83624 #Cormac son of Ailill
 	}
 	713.1.1 = {
-		holder = 83631 #Dub-dá-Crích son of Colmán
+		holder = 83631 #Dub-dï¿½-Crï¿½ch son of Colmï¿½n
 	}
 	752.1.1 = {
 		holder = 83640 #Indrechtach son of Flann
 	}
 	795.1.1 = {
-		holder = 83655 #Tnúthgal son of Donngus
+		holder = 83655 #Tnï¿½thgal son of Donngus
 	}
 	820.1.1 = {
 		holder = 83633 #Feidlimid mac Crimthainn, High-King of Ireland
 	}
 	847.1.1 = {
-		holder = 83657 #Ailgenán son of Donngal
+		holder = 83657 #Ailgenï¿½n son of Donngal
 	}
 	853.1.1 = {
-		holder = 83658 #Máel-Gualae son of Donngal
+		holder = 83658 #Mï¿½el-Gualae son of Donngal
 	}
 	859.1.1 = {
-		holder = 83672 #Dúnchad son of Dub-dá-Bairenn
+		holder = 83672 #Dï¿½nchad son of Dub-dï¿½-Bairenn
 	}
 	888.1.1 = {
-		holder = 83659 #Dub-Lachtna son of Máel-Gualae
+		holder = 83659 #Dub-Lachtna son of Mï¿½el-Gualae
 	}
 	895.1.1 = {
-		holder = 83675 #Finguine Cenn nGécán son of Láegaire
+		holder = 83675 #Finguine Cenn nGï¿½cï¿½n son of Lï¿½egaire
 	}
 	902.1.1 = {
-		holder = 83685 #Cormac son of Cuilennán
+		holder = 83685 #Cormac son of Cuilennï¿½n
 	}
 	908.1.1 = {
-		holder = 83692 #Lorcán son Condlígan
+		holder = 83692 #Lorcï¿½n son Condlï¿½gan
 	}
 	922.1.1 = {
-		holder = 83666 #Cellachán Caisil son of Buadachán
+		holder = 83666 #Cellachï¿½n Caisil son of Buadachï¿½n
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	954.1.1 = {
-		holder = 83646 #Máel-Fathardaig son of Flann
+		holder = 83646 #Mï¿½el-Fathardaig son of Flann
 	}
 	957.1.1 = {
-		holder = 83662 #Fer-Gráid son of Clérech
+		holder = 83662 #Fer-Grï¿½id son of Clï¿½rech
 	}
 	961.1.1 = {
-		holder = 83667 #Donnchad son of Cellachán Caisil
+		holder = 83667 #Donnchad son of Cellachï¿½n Caisil
 	}
 	963.1.1 = {
 		holder = 83365 #Ivar of Waterford
@@ -2222,7 +2219,7 @@ c_ormond = {
 		holder = 83367 #Ragnall of Waterford
 	}
 	1035.7.1 = {
-		holder = 83368 #Cú-Muman
+		holder = 83368 #Cï¿½-Muman
 	}
 	1038.7.1 = {
 		holder = 83370
@@ -2285,7 +2282,7 @@ c_desmond = {
 		holder = 83695 #Crimthann son of Echu
 	}
 	550.1.1 = {
-		holder = 83696 #Lóégaire son of Crimthann
+		holder = 83696 #Lï¿½ï¿½gaire son of Crimthann
 	}
 	557.1.1 = {
 		holder = 83697 #Aed Ualgarb son of Crimthann
@@ -2297,58 +2294,58 @@ c_desmond = {
 		holder = 83699 #Feidlimid son of Tigernach
 	}
 	593.1.1 = {
-		holder = 83713 #Aed Osraige son of Lóegaire
+		holder = 83713 #Aed Osraige son of Lï¿½egaire
 	}
 	597.1.1 = {
-		holder = 83700 #Cenn-Fáelad son of Feidlimid
+		holder = 83700 #Cenn-Fï¿½elad son of Feidlimid
 	}
 	624.1.1 = {
-		holder = 83701 #Fergus son of Cenn-Fáelad
+		holder = 83701 #Fergus son of Cenn-Fï¿½elad
 	}
 	654.1.1 = {
-		holder = 83702 #Bécc son of Fergus
+		holder = 83702 #Bï¿½cc son of Fergus
 	}
 	661.1.1 = {
-		holder = 83717 #Dond Sláine Brecc son of Dúngal
+		holder = 83717 #Dond Slï¿½ine Brecc son of Dï¿½ngal
 	}
 	676.1.1 = {
-		holder = 83718 #Éladach son of Dond Sláine
+		holder = 83718 #ï¿½ladach son of Dond Slï¿½ine
 	}
 	732.1.1 = {
-		holder = 83719 #Fergal son of Éladach
+		holder = 83719 #Fergal son of ï¿½ladach
 	}
 	779.1.1 = {
 		holder = 83705 #Connath son of Artgal
 	}
 	810.1.1 = {
-		holder = 83723 #Éladach son of Dúnlaing
+		holder = 83723 #ï¿½ladach son of Dï¿½nlaing
 	}
 	828.1.1 = {
 		holder = 83706 #Ailill Broga son of Connath
 	}
 	849.1.1 = {
-		holder = 83729 #Anilte son of Dúnlaing
+		holder = 83729 #Anilte son of Dï¿½nlaing
 	}
 	861.1.1 = {
-		holder = 83707 #Cú-Chongelt son of Ailill Broga
+		holder = 83707 #Cï¿½-Chongelt son of Ailill Broga
 	}
 	870.1.1 = {
-		holder = 83732 #Óengus son of Flaithnia
+		holder = 83732 #ï¿½engus son of Flaithnia
 	}
 	935.1.1 = {
 		government = feudal_government	#Ahistorical, just for ease of bookmarks.
 	}
 	936.1.1 = {
-		holder = 83710 #Spelán son of Cathnia
+		holder = 83710 #Spelï¿½n son of Cathnia
 	}
 	944.1.1 = {
-		holder = 83733 #Dub-dá-Bairenn son of Óengus
+		holder = 83733 #Dub-dï¿½-Bairenn son of ï¿½engus
 	}
 	959.1.1 = {
-		holder = 166120 #Máel-Muad mac Brain
+		holder = 166120 #Mï¿½el-Muad mac Brain
 	}
 	978.1.1 = {
-		holder = 166121 #Cían mac Máel-Muad
+		holder = 166121 #Cï¿½an mac Mï¿½el-Muad
 	}
 	1030.1.1 = {
 		holder = 83251 #Carthach progenitor of the MacCarthy kindred
@@ -2375,10 +2372,10 @@ c_desmond = {
 		liege = "k_england"
 	}
 	1175.7.1 = {
-		holder = 83271 #Cormac Liathánach son of Diarmait
+		holder = 83271 #Cormac Liathï¿½nach son of Diarmait
 	}
 	1176.7.1 = {
-		holder = 214600 #Domnall Mór na Corra son of Diarmait
+		holder = 214600 #Domnall Mï¿½r na Corra son of Diarmait
 	}
 	1185.1.1 = {
 		liege = "d_meath"
@@ -2387,16 +2384,16 @@ c_desmond = {
 		holder = 214609 #Fingen son of Diarmait
 	}
 	1207.7.1 = {
-		holder = 214601 #Diarmait Dúna Droignéin son of Domnall Mór
+		holder = 214601 #Diarmait Dï¿½na Droignï¿½in son of Domnall Mï¿½r
 	}
 	1211.7.1 = {
-		holder = 83267 #Cormac Óc Liathánach son of Cormac Liathánach
+		holder = 83267 #Cormac ï¿½c Liathï¿½nach son of Cormac Liathï¿½nach
 	}
 	1244.7.1 = {
-		holder = 214602 #Corman Finn son of Domnall Mór
+		holder = 214602 #Corman Finn son of Domnall Mï¿½r
 	}
 	1247.7.1 = {
-		holder = 83272 #Domnall Got Cairprech son of Domnall Mór
+		holder = 83272 #Domnall Got Cairprech son of Domnall Mï¿½r
 	}
 	1252.7.1 = {
 		holder = 83273 #Fingen of Rinrone son of Domnall Got Cairprech
@@ -2408,7 +2405,7 @@ c_desmond = {
 		holder = 83279 #Domnall Ruad son of Cormac Finn
 	}
 	1302.7.1 = {
-		holder = 83285 #Domnall Óc son of Domnall Ruad
+		holder = 83285 #Domnall ï¿½c son of Domnall Ruad
 	}
 	1306.7.1 = {
 		holder = 83280 #Donnchad Carrthainn son of Cormac Finn
@@ -2417,13 +2414,13 @@ c_desmond = {
 		liege = 0
 	}
 	1310.7.1 = {
-		holder = 83287 #Diarmait Óc of Tralee son of Domnall Óc
+		holder = 83287 #Diarmait ï¿½c of Tralee son of Domnall ï¿½c
 	}
 	1325.7.1 = {
-		holder = 83288 #Cormac son of  Domnall Óc
+		holder = 83288 #Cormac son of  Domnall ï¿½c
 	}
 	1359.7.1 = {
-		holder = 83289 #Domnall Óc son of Cormac
+		holder = 83289 #Domnall ï¿½c son of Cormac
 	}
 
 }


### PR DESCRIPTION
In 867 the duke of Meath originally held the title of d_meath as well as c_ailech. In the latest update c_ailech was given to a new elven noble, leaving the duke with only the title d_meath, which caused a few bugs. 

## Change:
* Destroyed title d_meath in 867 start date