### PR TITLE
Adding 'Mandatory Consanguinity'

### DIFF
--- a/common/religion/doctrines/00_core_tenets.txt
+++ b/common/religion/doctrines/00_core_tenets.txt
@@ -1,0 +1,3468 @@
+﻿doctrine_core_tenets = {
+	group = "core_tenets"
+	number_of_picks = 3
+
+	############################
+	# Christian Faith Tenets	#
+	############################
+
+	tenet_aniconism = {
+		icon = core_tenet_aniconism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = judaism_religion
+						religion_tag = islam_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_aniconism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			has_doctrine = abrahamic_hostility_doctrine
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_doctrine_mummification_trigger
+				NOT = { doctrine:doctrine_funeral_mummification = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		character_modifier = {
+			church_holding_build_speed = -0.33
+			church_holding_build_gold_cost = -0.33
+			church_holding_holding_build_speed = -0.33
+			church_holding_holding_build_gold_cost = -0.33
+		}
+
+		parameters = {
+			reforging_artifacts_costs_piety = yes
+			destroying_artifacts_is_pious = yes
+		}
+	}
+
+	tenet_alexandrian_catechism = {
+		icon = core_tenet_alexandrian_catechism
+		piety_cost = {
+			value = faith_tenet_cost_mid
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_alexandrian_catechism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = christianity_religion
+					}
+					desc = tenet_alexandrian_catechism_name
+				}
+				desc = tenet_islamic_rationalism_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = christianity_religion
+					}
+					desc = tenet_alexandrian_catechism_desc
+				}
+				desc = tenet_islamic_rationalism_desc
+			}
+		}
+
+		is_shown = {
+			OR = {
+				religion_tag = christianity_religion
+				religion_tag = islam_religion 
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = doctrine_pluralism_fundamentalist_trigger
+				NOT = { doctrine:doctrine_pluralism_fundamentalist = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		character_modifier = {
+			monthly_learning_lifestyle_xp_gain_mult = 0.2
+			learning_per_stress_level = 2
+		}
+
+		traits = {
+			virtues = { scholar }
+		}
+	}
+
+	tenet_armed_pilgrimages = {
+		icon = core_tenet_armed_pilgrimages
+		piety_cost = {
+			if = {
+				limit = { religion_tag = christianity_religion }
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_armed_pilgrimages }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			OR = {
+				religion_tag = christianity_religion
+				religion_tag = judaism_religion
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = { doctrine:tenet_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = { doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_armed_pilgrimages_vs_forbidden_pilgrimages
+				NOT = { doctrine:doctrine_pilgrimage_forbidden = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			cheaper_holy_wars_active = yes
+			great_holy_wars_active = yes
+			ghw_no_hof_conversion_buffs_active = yes
+			pilgrimage_decision_active = yes
+		}
+		character_modifier = {
+			accolade_glory_gain_mult = 0.1
+		}
+	}
+
+	tenet_carnal_exaltation = {
+		icon = core_tenet_carnal_exaltation
+		piety_cost = {
+			if = {
+				limit = {
+					religion_tag = hinduism_religion
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_massive
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_carnal_exaltation }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		character_modifier = {
+			fertility = 0.25
+		}
+
+		traits = {
+			virtues = { lustful }
+			sins = { chaste }
+		}
+	}
+
+	tenet_communal_identity = {
+		icon = core_tenet_communal_identity
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else = {
+				value = faith_tenet_cost_low
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_communal_identity }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_communal_identity_chosen_people_name
+				}
+				desc = tenet_communal_identity_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_communal_identity_chosen_people_desc
+				}
+				desc = tenet_communal_identity_desc
+			}
+		}
+
+		can_pick = {
+			always = yes
+		}
+
+		parameters = {
+			same_culture_conversion_bonus_active = yes
+			same_faith_promote_culture_bonus_active = yes
+			other_culture_conversion_penalty_active = yes
+		}
+
+		character_modifier = {
+			name = "tenet_communal_identity_opinion"
+			same_faith_opinion = 10
+		}
+	}
+
+	tenet_communion = {
+		icon = core_tenet_communion
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					has_doctrine = pagan_hostility_doctrine
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_communion }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		can_pick = {
+			custom_description = {
+				text = doctrine_requires_head_of_faith_trigger
+				NOT = {
+					doctrine:doctrine_no_head = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_sacred_shadows_trigger
+				NOT = {
+					has_doctrine = tenet_sacred_shadows
+				}
+			}
+		}
+
+		parameters = {
+			seek_indulgences_active = yes
+			seek_indulgences_active_2 = yes
+			excommunication_active = yes
+		}
+		traits = {
+			virtues = { honest }
+			sins = { deceitful }
+		}
+	}
+
+	tenet_consolamentum = {
+		icon = core_tenet_consolamentum
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = christianity_religion
+					}
+					desc = tenet_consolamentum_name
+				}
+				desc = tenet_consolamentum_name_alternate
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					has_doctrine = tenet_sacrificial_ceremonies
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = dualism_religion
+						religion_tag = hinduism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_consolamentum }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOR = {
+				religion_tag = islam_religion
+				religion_tag = judaism_religion
+				religion_tag = zoroastrianism_religion
+				AND = {
+					has_doctrine = pagan_hostility_doctrine
+					NOT = { religion_tag = kushitism_religion }
+				}
+			}
+		}
+		
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_sacrificial_ceremonies_trigger
+				NOT = { doctrine:tenet_sacrificial_ceremonies = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			consolamentum_active = yes
+		}
+
+		character_modifier = {
+			short_reign_duration_mult = -0.5
+		}
+	}
+
+	tenet_divine_marriage = {
+		icon = core_tenet_divine_marriage
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = zoroastrianism_religion
+					}
+					desc = tenet_divine_marriage_xwedodah 
+				}
+				desc = tenet_divine_marriage_name
+			}
+		}
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = dualism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_divine_marriage }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+
+		can_pick = {
+			custom_description = {
+				text = doctrine_unrestricted_consanguinity_trigger
+				OR = {
+					doctrine:doctrine_consanguinity_unrestricted = { is_in_list = selected_doctrines }
+					doctrine:doctrine_consanguinity_mandatory = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			divine_marriage_opinion = 10
+			divine_marriage_piety_gain_active = yes
+		}
+
+		traits = {
+			virtues = { pure_blooded = 2 }
+		}
+	}
+
+	tenet_gnosticism = {
+		icon = core_tenet_gnosticism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = dualism_religion
+						religion_tag = zoroastrianism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = judaism_religion
+						religion_tag = islam_religion
+						religion_tag = hinduism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_gnosticism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		traits = {
+			virtues = { temperate }
+			sins = { gluttonous }
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_eastern_syncretism_trigger
+				NOT = {
+					doctrine:tenet_eastern_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			hostility_override_tenet_gnosticism = 0
+			hostility_override_special_doctrine_is_gnostic_faith = 0
+			granting_titles_gives_stress = yes
+		}
+
+		character_modifier = {
+			learning = 2
+			stewardship = -2
+		}
+
+		is_shown = {
+			NOT = { has_doctrine = special_doctrine_is_gnostic_faith } # Can't be Gnostic if ye already are Gnostic
+		}
+	}
+
+	tenet_mendicant_preachers = {
+		icon = core_tenet_mendicant_preachers
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_mendicant_preachers }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_hedonistic_trigger
+				NOT = { doctrine:tenet_hedonistic = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			mendicant_preachers_conversion_active = yes
+			pilgrimage_decision_active = yes
+		}
+		traits = {
+			virtues = { temperate }
+			sins = { gluttonous }
+		}
+	}
+
+	tenet_monasticism = {
+		icon = core_tenet_monasticism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_monasticism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_hedonistic_trigger
+				NOT = { doctrine:tenet_hedonistic = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			take_vows_active = yes
+		}
+		traits = {
+			virtues = { temperate }
+			sins = { gluttonous }
+		}
+	}
+
+	tenet_pacifism = {
+		icon = core_tenet_pacifism
+		piety_cost = {
+			if = {
+				limit = {
+					religion_tag = christianity_religion
+					religion_tag = taoism_religion
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					religion_tag = islam_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_pacifism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOR = {
+				religion_tag = buddhism_religion
+				religion_tag = hinduism_religion
+				religion_tag = jainism_religion
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_human_sacrifice_trigger
+				NOT = { doctrine:tenet_human_sacrifice = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_armed_pilgrimages_trigger
+				NOT = { doctrine:tenet_armed_pilgrimages = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_gruesome_festivals_trigger
+				NOT = {
+					doctrine:tenet_gruesome_festivals = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			holy_wars_forbidden = yes
+			pacifist_opinion_active = yes
+			opinion_of_pacifist_opinion_active = 10
+			piety_from_long_peace = 1
+		}
+
+		traits = {
+			virtues = { calm }
+			sins = { wrathful }
+		}
+		
+		character_modifier = {
+			domain_limit = 1
+			ai_war_chance = -0.25
+			ai_war_cooldown = 5
+		}
+	}
+
+	tenet_pentarchy = {
+		icon = core_tenet_pentarchy
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = christianity_religion
+					}
+					desc = tenet_pentarchy_alternate_name
+				}
+				desc = tenet_pentarchy_name
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = hinduism_religion
+						religion_tag = zoroastrianism_religion
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else = {
+				value = faith_tenet_cost_high
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_pentarchy }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = doctrine_pluralism_pluralistic_trigger
+				NOT = { doctrine:doctrine_pluralism_pluralistic = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			fervor_per_holy_site = 1
+			pilgrimage_decision_active = yes
+		}
+	}
+
+	tenet_unrelenting_faith = {
+		icon = core_tenet_unrelenting_faith
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = judaism_religion
+						religion_tag = islam_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_unrelenting_faith }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		character_modifier = {
+			prowess = 4
+			tolerance_advantage_mod = 2
+		}
+		
+		parameters = {
+			clergy_can_fight = yes
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						OR = { 
+							has_doctrine = doctrine_heretic_branch_zandik
+							has_doctrine = tenet_pastoral_isolation
+						}
+					}
+					desc = tenet_unrelenting_faith_zandik_name
+				}
+				desc = tenet_unrelenting_faith_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						OR = { 
+							has_doctrine = doctrine_heretic_branch_zandik
+							has_doctrine = tenet_pastoral_isolation
+						}
+					}
+					desc = tenet_unrelenting_faith_zandik_desc
+				}
+				desc = tenet_unrelenting_faith_desc
+			}
+		}
+	}
+
+	tenet_vows_of_poverty = {
+		icon = core_tenet_vows_of_poverty
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_vows_of_poverty }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			always = yes
+		}
+
+		parameters = {
+			vows_of_poverty_active = yes
+		}
+
+		traits = {
+			virtues = { generous = 2 }
+			sins = { greedy = 2 }
+		}
+	}
+
+	tenet_pastoral_isolation = {
+		icon = core_tenet_pastoral_isolation
+
+		is_shown = {
+			religion_tag = christianity_religion
+		}
+		can_pick = {
+			custom_description = {
+				text = doctrine_no_head_of_faith_trigger
+				doctrine:doctrine_no_head = { is_in_list = selected_doctrines }
+			}
+			custom_description = {
+				text = incompatible_tenet_false_conversion_sanction_trigger
+				NOT = {
+					doctrine:tenet_false_conversion_sanction = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+		}
+
+		parameters = {
+			hostility_override_special_doctrine_is_christian_faith = 0
+			#For loc:
+			is_christian_faith_pastoral_isolation_loc_override = 0
+			sanctioned_false_conversion = yes
+			unattractive_for_character_conversions = yes
+		}
+
+		character_modifier = {
+			development_growth_factor = -0.1
+			different_faith_liege_opinion = 10
+			opinion_of_different_faith_liege = 10
+		}
+
+		traits = {
+		}
+	}
+
+	tenet_rite = {
+		icon = core_tenet_rite
+
+		is_shown = {
+			# Filter out religions that use a branch system.
+			NOR = {
+				religion = religion:islam_religion
+				religion = religion:zoroastrianism_religion
+			}
+			# We also only want people with existing spiritual HoFs.
+			exists = religious_head
+			has_doctrine_parameter = spiritual_head_of_faith
+		}
+
+		can_pick = {
+			# Must have a theocratic HoF.
+			custom_description = {
+				text = doctrine_requires_theocratic_head_of_faith_trigger
+				doctrine:doctrine_spiritual_head = { is_in_list = selected_doctrines }
+			}
+			# !!! SECTION NOTE !!!
+			## We check for tenets rather than doctrine parameters here because doctrine parameters cannot be checked in the selected_doctrines list, so we maintain such throughout the section for consistency.
+			# Some tenet/doctrine configurations are mutually exclusive.
+			## Pacifists vs. war-mongers.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_pacifists_vs_warmongers
+				NOR = {
+					# Either you're trying to be pacifist and your HoF hates it...
+					AND = {
+						OR = {
+							doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines }
+							doctrine:tenet_pacifism = { is_in_list = selected_doctrines }
+						}
+						religious_head.faith = {
+							OR = {
+								has_doctrine = tenet_armed_pilgrimages
+								has_doctrine = tenet_struggle_submission
+								has_doctrine = tenet_warmonger
+								has_doctrine = tenet_pursuit_of_power
+							}
+						}
+					}
+					# ... or your HoF is and hates your warmongering.
+					AND = {
+						OR = {
+							doctrine:tenet_armed_pilgrimages = { is_in_list = selected_doctrines }
+							doctrine:tenet_struggle_submission = { is_in_list = selected_doctrines }
+							doctrine:tenet_warmonger = { is_in_list = selected_doctrines }
+							doctrine:tenet_pursuit_of_power = { is_in_list = selected_doctrines }
+						}
+						religious_head.faith = {
+							OR = {
+								has_doctrine = tenet_dharmic_pacifism
+								has_doctrine = tenet_pacifism
+							}
+						}
+					}
+				}
+			}
+			## Criminal witches vs. adorcists.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_criminal_witches_vs_adorcists
+				NOR = {
+					# Either you're big on possessions but your HoF hates witchcraft...
+					AND = {
+						doctrine:tenet_adorcism = { is_in_list = selected_doctrines }
+						religious_head.faith = { has_doctrine = doctrine_witchcraft_crime }
+					}
+					# ... or you hate witchcraft but your HoF likes possessions.
+					AND = {
+						doctrine:doctrine_witchcraft_crime = { is_in_list = selected_doctrines }
+						religious_head.faith = { has_doctrine = tenet_adorcism }
+					}
+				}
+			}
+			## Hedonists vs. ascetics.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_hedonists_vs_ascetics
+				NOR = {
+					# Either you like to indulge but your HoF believes less is more...
+					AND = {
+						doctrine:tenet_hedonistic = { is_in_list = selected_doctrines }
+						religious_head.faith = { has_doctrine = tenet_asceticism }
+					}
+					# ... or your HoF throws constant wild parties whilst you prefer to sit and chill.
+					AND = {
+						doctrine:tenet_asceticism = { is_in_list = selected_doctrines }
+						religious_head.faith = { has_doctrine = tenet_hedonistic }
+					}
+				}
+			}
+			## Cannibals vs. non-cannibals of any kind.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_cannibals_vs_non_cannibals
+				NOR = {
+					# Cannibal-you doesn't get why your non-cannibal HoF freaks out when you offer them a hand...
+					AND = {
+						doctrine:tenet_ritual_cannibalism = { is_in_list = selected_doctrines }
+						NOT = {
+							religious_head.faith = { has_doctrine = tenet_ritual_cannibalism }
+						}
+					}
+					# ... or cannibal-HoF thinks you need to chill the hell out whilst they eat this dude.
+					AND = {
+						religious_head.faith = { has_doctrine = tenet_ritual_cannibalism }						
+						NOT = {
+							doctrine:tenet_ritual_cannibalism = { is_in_list = selected_doctrines }
+						}
+					}
+				}
+			}
+			# Some tenet/doctrine configurations are unilaterally exclusive.
+			## HumSac/GruFes are disliked by anyone who doesn't also actively believe in such.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_world_vs_humsac_grufes
+				# Your HoF will not put up with your HumSackery if they don't also go in for it.
+				trigger_if = {
+					limit = {
+						OR = {
+							doctrine:tenet_gruesome_festivals = { is_in_list = selected_doctrines }
+							doctrine:tenet_human_sacrifice = { is_in_list = selected_doctrines }
+						}
+					}
+					NOR = {
+						religious_head.faith = { has_doctrine = tenet_gruesome_festivals }
+						religious_head.faith = { has_doctrine = tenet_human_sacrifice }
+					}
+				}
+			}
+			## Monogamy doesn't like polygamy.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_monogamy_vs_polygamy
+				# Monogamous HoFs do not appreciate polygamy.
+				trigger_if = {
+					limit = {
+						doctrine:doctrine_polygamy = { is_in_list = selected_doctrines }
+					}
+					NOT = {
+						religious_head.faith = { has_doctrine = doctrine_monogamy }
+					}
+				}
+			}
+			## All lesser variations of incest don't like unrestricted incest.
+			custom_description = {
+				text = incompatible_tenet_shared_hof_world_vs_unrestricted_incest
+				# Non-incestual HoFs really take issue with unrestricted incest.
+				trigger_if = {
+					limit = {
+						doctrine:doctrine_consanguinity_unrestricted = { is_in_list = selected_doctrines }
+					}
+					religious_head.faith = { has_doctrine = doctrine_consanguinity_unrestricted }
+				}
+			}
+		}
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+		}
+
+		parameters = {
+			maintains_head_of_faith_on_creation = yes
+			# For loc:
+			ecumenical_christians_keep_ecumenism = yes
+			# And finally, you and your old faith see each other as astray.
+			## Please note, unlike other hostility overrides, this is _bilateral_, not unilateral.
+			same_hof_hostility_override = 1
+		}
+
+		character_modifier = {
+			faith_creation_piety_cost_mult = -0.25
+			opinion_of_same_faith = 5
+			religious_head_opinion = -10
+		}
+	}
+
+	############################
+	#	Muslim Faith Tenets	#
+	############################
+
+	tenet_adaptive = {
+		icon = core_tenet_adaptive
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = islam_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = judaism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_adaptive }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = doctrine_inverted_pluralism_pluralistic_trigger
+				NOR = {
+					doctrine:doctrine_pluralism_fundamentalist = { is_in_list = selected_doctrines }
+					doctrine:doctrine_pluralism_righteous = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			tenet_adaptive_conversion_resistance = yes
+			reduced_vassal_religion_discontent = yes
+		}
+
+		character_modifier = {
+			different_faith_county_opinion_mult = -0.25
+			different_faith_liege_opinion = 15
+			opinion_of_different_faith_liege = 15
+		}
+	}
+
+	tenet_esotericism = {
+		icon = core_tenet_esotericism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+						religion_tag = jainism_religion
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_esotericism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		traits = {
+			virtues = {
+				lifestyle_mystic = { weight = 1 }
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_esotericism_kabbalah
+				}
+				desc = tenet_esotericism_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_esotericism_kabbalah_desc
+				}
+				desc = tenet_esotericism_desc
+			}
+		}
+
+		parameters = {
+			tenet_esotericism_mystic_education = yes
+		}
+	}
+
+	tenet_legalism = {
+		icon = core_tenet_legalism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = judaism_religion
+						religion_tag = zoroastrianism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_legalism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		traits = {
+			virtues = { just = 2 }
+			sins = { arbitrary = 2 }
+		}
+
+		parameters = {
+			legalism_modified_law_costs = yes
+			legalism_modified_law_costs_2 = yes
+			legalism_reduced_faction_virtues = yes
+			legalism_increased_faction_sins = yes
+			legalism_trust_just_leader_active = yes
+		}
+	}
+
+	tenet_literalism = {
+		icon = core_tenet_literalism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_literalism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+
+			if = {
+				limit = { NOT = { has_doctrine = abrahamic_hostility_doctrine } }
+				multiply = 1.5
+				round = yes
+			}
+		}
+
+		traits = {
+			virtues = {
+				education_learning_3
+				education_learning_4
+				education_learning_5
+				scholar
+			}
+		}
+
+		parameters = {
+			literalist_debate_enabled = yes
+		}
+	}
+
+	tenet_reincarnation = {
+		icon = core_tenet_reincarnation
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = dualism_religion
+						religion_tag = hinduism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_reincarnation }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOR = {
+				AND = {
+					religion_tag = christianity_religion
+					NOT = { this = faith:cathar }
+				}
+				religion_tag = judaism_religion
+			}
+		}
+
+		parameters = {
+			reincarnation_resistance_to_conversion = yes
+			reincarnation_events_active = yes
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = zoroastrianism_religion
+					}
+					desc = tenet_reincarnation_zoroastrian_name
+				}
+				desc = tenet_reincarnation_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = zoroastrianism_religion
+					}
+					desc = tenet_reincarnation_zoroastrian_desc
+				}
+				desc = tenet_reincarnation_desc
+			}
+		}
+	}
+
+	tenet_religious_legal_pronouncements = {
+		icon = core_tenet_legal_pronouncements
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = hinduism_religion
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_religious_legal_pronouncements }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = islam_religion
+					}
+					desc = tenet_religious_legal_pronouncements_fatwa
+				}
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_religious_legal_pronouncements_halakha
+				}
+				desc = tenet_religious_legal_pronouncements_name
+			}
+		}
+
+		parameters = {
+			temporal_condemnation_enabled = yes
+			religious_legal_pronouncements_law_cost_reduction = yes
+		}
+	}
+
+	tenet_struggle_submission = {
+		icon = core_tenet_struggle_submission
+		piety_cost = {
+			if = {
+				limit = {
+					religion_tag = islam_religion
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_high
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_struggle_submission }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			OR = {
+				religion_tag = islam_religion
+				religion_tag = dualism_religion
+			}
+		}
+
+		parameters = {
+			great_holy_wars_active = yes
+			ghw_no_hof_conversion_buffs_active = yes
+			bonus_holy_war_piety_active = yes
+			pilgrimage_decision_active = yes
+		}
+	}
+
+	tenet_false_conversion_sanction = {
+		icon = core_tenet_false_conversion_sanction
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = islam_religion
+					}
+					desc = tenet_temporal_condemnation_taqiya
+				}
+				triggered_desc = {
+					trigger = {
+						religion_tag = judaism_religion
+					}
+					desc = tenet_anusim
+				}
+				desc = tenet_false_conversion_sanction_name
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = dualism_religion
+						religion_tag = hinduism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = zoroastrianism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_false_conversion_sanction }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			sanctioned_false_conversion = yes
+		}
+
+		character_modifier = {
+			monthly_intrigue_lifestyle_xp_gain_mult = 0.1 #FP3 addition to make this tenet more attractive
+		}
+	}
+
+	tenet_tax_nonbelievers = {
+		icon = core_tenet_tax_nonbelievers
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_tax_nonbelievers }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = islam_religion
+					}
+					desc = tenet_tax_nonbelievers_jizya_name
+				}
+				desc = tenet_tax_nonbelievers_name
+			}
+		}
+
+		character_modifier = {
+			domain_tax_different_faith_mult = 0.2
+			levy_reinforcement_rate_same_faith = 0.25
+			levy_reinforcement_rate_different_faith = -0.25
+		}
+
+		parameters = {
+			unlock_jizya_contract = yes
+		}
+
+		is_shown = {
+			NOT = { religion_tag = christianity_religion }
+			NOT = { has_doctrine = special_doctrine_jizya }
+		}
+	}
+
+	#############################
+	# Eastern Faith tenets 		#
+	#############################
+
+	tenet_asceticism = {
+		icon = core_tenet_asceticism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+						religion_tag = taoism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_asceticism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		
+
+		parameters = {
+			meditation_mechanics_active = yes
+		}
+
+		#name = { #FP3 - Removed and saved for posterity. Zurvanism would fit a future hypotetical "Fatalism" tenet, but Asceticism isn't a good fit, per beta input. Ola's note. 
+		#	first_valid = {
+		#		triggered_desc = {
+		#			trigger = {
+		#				religion_tag = zoroastrianism_religion
+		#			}
+		#			desc = tenet_zurvanism_name
+		#		}
+		#		desc = tenet_asceticism_name
+		#	}
+		#}
+
+		#desc = {
+		#	first_valid = {
+		#		triggered_desc = {
+		#			trigger = {
+		#				religion_tag = zoroastrianism_religion
+		#			}
+		#			desc = tenet_zurvanism_desc
+		#		}
+		#		desc = tenet_asceticism_desc
+		#	}
+		#}
+
+		traits = {
+			virtues = {
+				temperate
+			}
+			sins = {
+				gluttonous
+				greedy
+				lifestyle_reveler
+			}
+		}
+	}
+
+	tenet_bhakti = {
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = { religion_tag = hinduism_religion }
+					desc = tenet_bhakti_name
+				}
+				desc = tenet_bhakti_patron_god_name
+			}
+		}
+		icon = core_tenet_bhakti
+
+		piety_cost = faith_tenet_cost_mid
+
+		is_shown = {
+			OR = {
+				religion_tag = hinduism_religion
+				# With FP1, Germanics also get personal deities.
+				AND = {
+					religion_tag = germanic_religion
+					has_fp1_dlc_trigger = yes
+				}
+			}
+		}
+
+		parameters = {
+			select_personal_god_active = yes
+		}
+	}
+
+	tenet_dharmic_pacifism = { #Mix of reincarnation and pacifism rites
+		icon = core_tenet_dharmic_pacifism
+		is_shown = {
+			has_doctrine = eastern_hostility_doctrine
+			NOT = { religion_tag = zoroastrianism_religion }
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_dharmic_pacifism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_human_sacrifice_trigger
+				NOT = { doctrine:tenet_human_sacrifice = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_armed_pilgrimages_trigger
+				NOT = { doctrine:tenet_armed_pilgrimages = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_gruesome_festivals_trigger
+				NOT = {
+					doctrine:tenet_gruesome_festivals = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+		
+		parameters = {
+			reincarnation_resistance_to_conversion = yes
+			holy_wars_forbidden = yes
+			pacifist_opinion_active = yes
+			opinion_of_pacifist_opinion_active = 10
+		}
+
+		traits = {
+			virtues = { calm }
+			sins = { wrathful }
+		}
+		
+		character_modifier = {
+			domain_limit = 1
+			ai_war_chance = -0.25
+			ai_war_cooldown = 0.25
+		}
+	}
+
+	tenet_inner_journey = {
+		icon = core_tenet_inner_journey
+
+		is_shown = {
+			has_doctrine = eastern_hostility_doctrine
+			NOT = { religion_tag = zoroastrianism_religion }
+		}
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_inner_journey }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		traits = {
+			virtues = { patient }
+			sins = { impatient }
+		}
+
+		parameters = {
+			meditation_mechanics_active = yes
+		}
+	}
+
+	tenet_ritual_hospitality = {
+		icon = core_tenet_ritual_hospitality
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_ritual_hospitality }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOT = {
+				has_doctrine = abrahamic_hostility_doctrine
+			}
+		}
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = hinduism_religion
+					}
+					desc = tenet_ritual_hospitality_alternate_name
+				}
+				desc = tenet_ritual_hospitality_name
+			}
+		}
+
+		parameters = {
+			host_honored_guests_active = yes
+		}
+
+		traits = {
+			virtues = {
+				generous
+			}
+			sins = {
+				callous
+			}
+		}
+
+		character_modifier = {
+			monthly_piety_gain_per_happy_powerful_vassal_add = 0.3
+		}
+	}
+
+	############################
+	# Pagan Faith Tenets  		#
+	############################
+
+	tenet_adorcism = {
+		icon = core_tenet_adorcism
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_adorcism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			OR = {
+				religion_tag = west_african_bori_religion
+				religion_tag = akom_religion
+			}
+		}
+
+		parameters = {
+			spirit_possession_active = yes
+		}
+
+		traits = {
+			virtues = { possessed = 2 }
+		}
+	}
+
+	tenet_ancestor_worship = {
+		icon = core_tenet_ancestor_worship
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_ancestor_worship }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			has_doctrine = pagan_hostility_doctrine
+		}
+
+		parameters = {
+			increased_dynasty_prestige_birth_mult = 1
+			increased_dynasty_prestige_marriage_mult = 1
+			increased_dynasty_prestige_long_reign_mult = 0.5
+			pilgrimage_decision_active = yes
+		}
+
+		character_modifier = {
+			close_relative_opinion = 5
+		}
+	}
+
+	tenet_astrology = {
+		icon = core_tenet_astrology
+		name = { #FP3
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						OR = {
+							religion_tag = islam_religion 
+							religion_tag = zoroastrianism_religion
+						}
+					}
+					desc = tenet_divination_name
+				}
+				desc = tenet_astrology_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						OR = {
+							religion_tag = islam_religion 
+							religion_tag = zoroastrianism_religion
+						}
+					}
+					desc = tenet_divination_desc
+				}
+				desc = tenet_astrology_desc
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = judaism_religion
+						religion_tag = islam_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_astrology }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			divine_the_stars_active = yes
+		}
+
+		character_modifier = {
+			naval_movement_speed_mult = 0.25
+		}
+	}
+
+	tenet_hedonistic = {
+		icon = core_tenet_hedonistic
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_massive
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_hedonistic }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOT = { religion_tag = dualism_religion }
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_monasticism_trigger
+				NOT = { doctrine:tenet_monasticism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_mendicant_preachers_trigger
+				NOT = { doctrine:tenet_mendicant_preachers = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			piety_from_feasts_active = yes
+		}
+
+		traits = {
+			virtues = { gluttonous = { scale = 2 weight = 2 } }
+			sins = { temperate = { scale = 2 weight = 2 } }
+		}
+
+		character_modifier = {
+			stress_loss_mult = 0.2
+		}
+	}
+
+	tenet_human_sacrifice = {
+		icon = core_tenet_human_sacrifice
+		piety_cost = {
+			if = {
+				limit = {
+					has_doctrine = tenet_sacrificial_ceremonies
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					has_doctrine = pagan_hostility_doctrine
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					religion_tag = hinduism_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_human_sacrifice }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			# No HumSac for Abrahamics: 'tis literally the religion-namer.
+			NOR = {
+				religion_tag = christianity_religion
+				religion_tag = judaism_religion
+				religion_tag = islam_religion
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = { doctrine:tenet_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = { doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_gruesome_festivals_trigger
+				NOT = {
+					doctrine:tenet_gruesome_festivals = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_sacrificial_ceremonies_trigger
+				NOT = {
+					doctrine:tenet_sacrificial_ceremonies = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			human_sacrifice_active = yes
+			flower_war_cb_active = yes
+		}
+
+		character_modifier = {
+			ai_war_chance = 1
+			ai_war_cooldown = -0.5
+		}
+	}
+
+	tenet_mystical_birthright = {
+		icon = core_tenet_mystical_birthright
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_mystical_birthright }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			religion_tag = magyar_religion
+		}
+
+		parameters = {
+			mystic_birthright_active = yes
+		}
+
+		traits = {
+			virtues = { 
+				lifestyle_mystic = { 
+					scale = 5 
+					weight = 2 
+				} 
+			}
+		}
+	}
+
+	tenet_ritual_celebrations = {
+		icon = core_tenet_ritual_celebrations
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+						religion_tag = zoroastrianism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_ritual_celebrations }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			piety_from_feasts_active = yes
+			mandatory_feast_attendance = yes
+		}
+
+		character_modifier = {
+			vassal_opinion = 5
+			courtier_opinion = 5
+		}
+	}
+
+	tenet_sacred_childbirth = {
+		icon = core_tenet_sacred_childbirth
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = baltic_religion
+					}
+					desc = tenet_sacred_childbirth_alternate_name
+				}
+				desc = tenet_sacred_childbirth_name
+			}
+		}
+
+		piety_cost = {
+			value = faith_tenet_cost_low
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_sacred_childbirth }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			safer_childbirths_active = yes
+			healthier_children_active = yes
+			piety_from_childbirth_active = yes
+		}
+
+		character_modifier = {
+			fertility = 0.1
+		}
+
+		traits = {
+			virtues = { pregnant }
+		}
+	}
+
+	tenet_sanctity_of_nature = {
+		icon = core_tenet_sanctity_of_nature
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					has_doctrine = abrahamic_hostility_doctrine
+				}
+				value = faith_tenet_cost_massive
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_sanctity_of_nature }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			believes_in_harmony_with_nature_invisible = yes
+		}
+
+		character_modifier = {
+			forest_advantage = 5
+			forest_attrition_mult = -0.25
+			taiga_advantage = 5
+			taiga_attrition_mult = -0.25
+			jungle_advantage = 5
+			jungle_attrition_mult = -0.25
+			build_gold_cost = 0.1
+			county_opinion_add = 5
+		}
+	}
+
+	tenet_sun_worship = {
+		icon = core_tenet_sun_worship
+
+		piety_cost = {
+			value = faith_tenet_cost_mid
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_sun_worship }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			OR = {
+				religion_tag = zunism_religion
+				has_doctrine = tenet_sun_worship #If you already have it
+				AND = {
+					religion_tag = hinduism_religion
+					this = faith:saura #If you're into Saurism
+				}
+				
+			}
+		}
+
+		parameters = {
+			summer_festivals_active = yes
+			trial_by_sun_active = yes
+		}
+
+		character_modifier = {
+			desert_attrition_mult = -0.25
+			desert_mountains_attrition_mult = -0.25
+		}
+
+		piety_cost = faith_tenet_cost_mid
+	}
+
+	tenet_warmonger = {
+		icon = core_tenet_warmonger
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+						religion_tag = taoism_religion
+					}
+				}
+				value = faith_tenet_cost_massive
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_warmonger }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOR = {
+				religion_tag = christianity_religion
+				religion_tag = islam_religion
+				religion_tag = judaism_religion
+				religion_tag = dualism_religion
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = { doctrine:tenet_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = { doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			warmonger = yes
+			conquest_cb_enabled = yes
+			invasion_cb_enabled = yes
+			great_holy_wars_active_if_reformed = yes
+			clergy_can_fight = yes
+		}
+		
+		character_modifier = {
+			ai_war_chance = 0.5
+			ai_war_cooldown = -0.25
+			accolade_glory_gain_mult = 0.1
+		}
+	}
+
+	tenet_gruesome_festivals = {
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = { religion_tag = germanic_religion }
+					desc = tenet_gruesome_festivals_blot_name
+				}
+				desc = tenet_gruesome_festivals_name
+			}
+		}
+
+		icon = core_tenet_gruesome_festivals
+
+		piety_cost = {
+			# If you've already got human sacrifice, this is a nice and easy jump.
+			if = {
+				limit = { 
+					has_doctrine = tenet_human_sacrifice
+				}
+				value = faith_tenet_cost_low
+			}
+			# Otherwise, follow the same pricing tiers as tenet_human_sacrifice.
+			else_if = {
+				limit = {
+					has_doctrine = pagan_hostility_doctrine
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					religion_tag = hinduism_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_gruesome_festivals }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			# No HumSac for Abrahamics: 'tis literally the religion-namer.
+			NOR = {
+				religion_tag = christianity_religion
+				religion_tag = judaism_religion
+				religion_tag = islam_religion
+			}
+			# And DLC required.
+			has_fp1_dlc_trigger = yes
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = {
+					doctrine:tenet_pacifism = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = {
+					doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_human_sacrifice_trigger
+				NOT = {
+					doctrine:tenet_human_sacrifice = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_sacrificial_ceremonies_trigger
+				NOT = {
+					doctrine:tenet_sacrificial_ceremonies = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			human_sacrifice_active = yes
+			gruesome_festivals_active = yes
+		}
+	}
+
+	tenet_cthonic_redoubts = {
+		icon = core_tenet_cthonic_redoubts
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = north_african_religion
+					}
+					desc = tenet_volcanic_veneration_name
+				}
+				desc = tenet_cthonic_redoubts_name
+			}
+		}
+
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = north_african_religion
+					}
+					desc = tenet_volcanic_veneration_desc
+				}
+				desc = tenet_cthonic_redoubts_desc
+			}
+		}
+
+		piety_cost = {
+			value = faith_tenet_cost_mid
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_cthonic_redoubts }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			# Multiplier for traditional mountain-based religions or faiths.
+			if = {
+				limit = {
+					OR = {
+						this = faith:bosnian_church
+						this = faith:armenian_apostolic
+						this = faith:lamaism
+						this = faith:vajrayana
+						this = faith:mahayana
+						this = faith:haymanot
+						religion = religion:basque_religion
+						religion = religion:kushitism_religion
+						religion = religion:zunism_religion
+						religion = religion:tani_religion
+						religion = religion:qiangic_religion
+						religion = religion:bon_religion
+					}
+				}
+				multiply = faith_tenet_discount_mountain_background_value
+			}
+		}
+
+		is_shown = { always = yes }
+
+		parameters = {
+			easier_to_convert_faith_in_mountains = yes
+			easier_to_convert_culture_in_same_faith_mountains = yes
+			harder_to_convert_faith_away_in_mountains = yes
+		}
+
+		character_modifier = {
+			mountains_attrition_mult = -0.5
+			mountains_levy_size = 0.3
+			mountains_advantage = 5
+			desert_mountains_attrition_mult = -0.5
+			desert_mountains_levy_size = 0.3
+			desert_mountains_advantage = 5
+		}
+
+		piety_cost = faith_tenet_cost_mid
+
+		traits = {
+			virtues = {
+				# For the Jentillaks et al.
+				giant
+			}
+		}
+	}
+
+	#############################
+	# Syncretic Faith Tenets	#
+	#############################
+
+	tenet_eastern_syncretism = {
+		icon = core_tenet_eastern_syncretism
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = dualism_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					religion_tag = islam_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_eastern_syncretism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			OR = {
+				has_doctrine = abrahamic_hostility_doctrine
+				has_doctrine = pagan_hostility_doctrine
+			}
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_gnosticism_trigger
+				NOT = {
+					doctrine:tenet_gnosticism = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_other_syncretism_trigger
+				NOR = {
+					doctrine:tenet_unreformed_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_christian_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_islamic_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_jewish_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+		parameters = {
+			hostility_override_eastern_hostility_doctrine = 1
+			#For loc:
+			is_eastern_faith_bilateral_loc_override = 1
+			eastern_syncretic_actor_opinion_active = yes
+			opinion_of_eastern_syncretic_recipient_opinion_active = 30 #Sync this to syncretic_mutual_opinion_bonus_value
+		}
+		traits = {
+			virtues = { honest }
+			sins = { wrathful }
+		}
+	}
+
+	tenet_unreformed_syncretism = {
+		icon = core_tenet_unreformed_syncretism 
+		piety_cost = {
+			if = {
+				limit = { doctrine:doctrine_pluralism_pluralistic = {is_in_list = selected_doctrines} }
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = { doctrine:doctrine_pluralism_fundamentalist = {is_in_list = selected_doctrines} }
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_unreformed_syncretism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+
+		is_shown = {
+			NOT = { has_doctrine = pagan_hostility_doctrine }
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_other_syncretism_trigger
+				NOR = {
+					doctrine:tenet_eastern_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_christian_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_islamic_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_jewish_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+		parameters = {
+			hostility_override_unreformed_faith_doctrine = 2
+			hostility_override_west_african_unreformed_faith_doctrine = 2
+			unreformed_syncretic_actor_opinion_active = yes
+			opinion_of_unreformed_syncretic_recipient_opinion_active = 30 #Sync this to syncretic_mutual_opinion_bonus_value
+			unreformed_syncretic_conversion_malus_active = yes
+		}
+		traits = {
+			virtues = { humble }
+			sins = { arrogant }
+		}
+	}
+
+	tenet_christian_syncretism = {
+		icon = core_tenet_christian_syncretism
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = dualism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_christian_syncretism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOT = { religion_tag = christianity_religion }
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_other_syncretism_trigger
+				NOR = {
+					doctrine:tenet_eastern_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_unreformed_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_islamic_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_jewish_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			hostility_override_special_doctrine_is_christian_faith = 2
+			#For loc:
+			is_christian_faith_bilateral_loc_override = 2
+			# This parameter is empty; the syncretic religious trigger checks against the doctrine, as that's much clearer in tooltips and allows us to use a unified syncretic trigger per-religion rather than having bitty situational triggers.
+			can_use_christian_artefacts = yes
+			christian_syncretic_actor_opinion_active = yes
+			opinion_of_christian_syncretic_recipient_opinion_active = 30 #Sync this to syncretic_mutual_opinion_bonus_value
+		}
+
+		traits = {
+			virtues = { compassionate }
+			sins = { callous sadistic }
+		}
+	}
+
+	tenet_islamic_syncretism = {
+		icon = core_tenet_islamic_syncretism
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_islamic_syncretism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOT = { religion_tag = islam_religion }
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_other_syncretism_trigger
+				NOR = {
+					doctrine:tenet_eastern_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_unreformed_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_christian_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_jewish_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			hostility_override_special_doctrine_is_islamic_faith = 2
+			# This parameter is empty; the syncretic religious trigger checks against the doctrine, as that's much clearer in tooltips and allows us to use a unified syncretic trigger per-religion rather than having bitty situational triggers.
+			can_use_islamic_artefacts = yes
+			islamic_syncretic_actor_opinion_active = yes
+			opinion_of_islamic_syncretic_recipient_opinion_active = 30 #Sync this to syncretic_mutual_opinion_bonus_value
+		}
+
+		traits = {
+			virtues = { generous }
+			sins = { greedy arbitrary }
+		}
+	}
+
+	tenet_jewish_syncretism = {
+		icon = core_tenet_jewish_syncretism
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = judaism_religion
+						religion_tag = christianity_religion
+						religion_tag = dualism_religion
+					}
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_jewish_syncretism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			NOT = { religion_tag = judaism_religion }
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_other_syncretism_trigger
+				NOR = {
+					doctrine:tenet_eastern_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_unreformed_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_christian_syncretism = { is_in_list = selected_doctrines }
+					doctrine:tenet_islamic_syncretism = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			hostility_override_special_doctrine_is_jewish_faith = 2
+			# This parameter is empty; the syncretic religious trigger checks against the doctrine, as that's much clearer in tooltips and allows us to use a unified syncretic trigger per-religion rather than having bitty situational triggers.
+			can_use_jewish_artefacts = yes
+			jewish_syncretic_actor_opinion_active = yes
+			opinion_of_jewish_syncretic_recipient_opinion_active = 30 #Sync this to syncretic_mutual_opinion_bonus_value
+		}
+
+		traits = {
+			virtues = { patient }
+			sins = { cynical greedy }
+		}
+	}
+
+	#############################
+	# Custom Faith Tenets		#
+	#############################
+
+	tenet_exaltation_of_pain = {
+		icon = core_tenet_human_sacrifice
+
+		is_shown = {}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = hinduism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_exaltation_of_pain }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			torturing_prisoners_grants_piety = yes
+			reduced_stress_from_torture = yes
+			self_mutilation_active = yes
+		}
+
+		traits = {
+			virtues = {
+				sadistic
+			}
+			sins = {
+				compassionate
+			}
+		}
+	}
+
+	tenet_natural_primitivism = {
+		icon = core_tenet_natural_primitivism
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_with_crimes_trigger
+				NOR = {
+					doctrine:doctrine_adultery_women_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_homosexuality_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_adultery_men_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_witchcraft_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_deviancy_crime = { is_in_list = selected_doctrines }
+				}
+				OR = {
+					doctrine:doctrine_kinslaying_accepted = { is_in_list = selected_doctrines }
+					doctrine:doctrine_kinslaying_shunned = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					religion = religion:hinduism_religion
+					religion = religion:jainism_religion
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					has_doctrine = pagan_hostility_doctrine
+					religion = religion:buddhism_religion
+					religion = religion:christianity_religion
+					religion = religion:dualism_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_natural_primitivism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			naked_adherents_active = yes
+			natural_primitivism_law_cost_increase = yes
+		}
+
+		character_modifier = {
+			tyranny_gain_mult = 1.00
+			stress_gain_mult = -0.25
+			stress_loss_mult = 0.25
+		}
+	}
+
+	tenet_pursuit_of_power = {
+		icon = core_tenet_pursuit_of_power
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						has_doctrine = pagan_hostility_doctrine
+						religion_tag = hinduism_religion
+						religion_tag = islam_religion
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_pursuit_of_power }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			conquest_cb_enabled = yes
+			invasion_cb_enabled = yes
+		}
+
+		character_modifier = {
+			title_creation_cost_mult = -0.5
+			tyranny_gain_mult = -0.5
+			direct_vassal_opinion = -10
+		}
+
+		traits = {
+			virtues = {
+				ambitious
+				disloyal
+			}
+			sins = {
+				content
+				loyal
+			}
+		}
+	}
+
+	tenet_ritual_cannibalism = {
+		icon = core_tenet_ritual_cannibalism
+
+		piety_cost = {
+			if = {
+				limit = {
+					has_variable = accepted_cannibalism
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					religion_tag = hinduism_religion
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_ritual_cannibalism }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		traits = {
+			virtues = {
+				cannibal = 2
+			}
+		}
+
+		parameters = {
+			cannibalism_legal = yes
+		}
+	}
+
+	tenet_sacred_shadows = {
+		icon = core_tenet_sacred_shadows
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						has_doctrine = pagan_hostility_doctrine
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = islam_religion
+						religion_tag = judaism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_sacred_shadows }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_communion_trigger
+				NOT = {
+					has_doctrine = tenet_communion
+				}
+			}
+		}
+
+		parameters = {
+			piety_gain_from_successful_intrigue_schemes = yes
+			adherents_more_likely_to_join_schemes = yes
+		}
+
+		traits = {
+			virtues = { deceitful }
+			sins = { honest }
+		}
+	}
+
+	tenet_polyamory = {
+		icon = core_tenet_polyamory
+		piety_cost = {
+			if = {
+				limit = {
+					religion_tag = hinduism_religion
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					OR = {
+						religion_tag = christianity_religion
+						religion_tag = judaism_religion
+						religion_tag = islam_religion
+						religion_tag = buddhism_religion
+						religion_tag = jainism_religion
+					}
+				}
+				value = faith_tenet_cost_high
+			}
+			else = {
+				value = faith_tenet_cost_mid
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_polyamory }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = ADULTERY_MUST_BE_FULLY_ACCEPTED
+				NOR = {
+					doctrine:doctrine_adultery_women_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_adultery_women_shunned = { is_in_list = selected_doctrines }
+					doctrine:doctrine_adultery_men_crime = { is_in_list = selected_doctrines }
+					doctrine:doctrine_adultery_men_shunned = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			no_unfaithfulness_penalty_active = yes
+		}
+	}
+	
+	tenet_sacrificial_ceremonies = {
+		icon = core_tenet_human_sacrifice
+
+		name = {
+			first_valid = {
+				desc = tenet_sacrificial_ceremonies_name
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					has_doctrine = tenet_human_sacrifice
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = {
+					has_doctrine = pagan_hostility_doctrine
+				}
+				value = faith_tenet_cost_mid
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+			
+			#We already practice sacrificial ceremonies
+			if = {
+				limit = { has_doctrine = tenet_sacrificial_ceremonies }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			religion_tag = north_african_religion
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = { doctrine:tenet_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = { doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_gruesome_festivals_trigger
+				NOT = {
+					doctrine:tenet_gruesome_festivals = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_human_sacrifice_trigger
+				NOT = {
+					doctrine:tenet_human_sacrifice = { is_in_list = selected_doctrines }
+				}
+			}
+			custom_description = {
+				text = incompatible_tenet_consolamentum_trigger
+				NOT = { doctrine:tenet_consolamentum = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			human_sacrifice_active = yes
+			consolamentum_active = yes
+		}
+
+		character_modifier = {
+			short_reign_duration_mult = -0.5
+			ai_war_chance = 1
+			ai_war_cooldown = -0.5
+		}
+	}
+	
+	tenet_megaliths = {
+		icon = core_tenet_megaliths
+
+		name = {
+			first_valid = {
+				desc = tenet_megaliths_name
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					has_doctrine = tenet_natural_primitivism
+				}
+				value = faith_tenet_cost_low
+			}
+			else_if = {
+				limit = { #Reduction in cost for Celtic Christianity because of stone circle shenanigans
+					this = faith:insular_celtic
+				}
+				value = faith_tenet_cost_mid
+			}
+			else = {
+				value = faith_tenet_cost_high
+			}
+			
+			#We already practice megaliths
+			if = {
+				limit = { has_doctrine = tenet_megaliths }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		is_shown = {
+			
+		}
+
+		can_pick = {
+			
+		}
+
+		parameters = {
+			can_build_megaliths = yes
+		}
+
+		character_modifier = {
+			hills_development_growth_factor = 0.15
+			hills_tax_mult = 0.1
+			hills_levy_size = 0.3
+			hills_advantage = 5
+		}
+	}
+
+	#############################
+	# FP3 Tenets 		#        
+	#############################
+
+	tenet_fp3_fedayeen = {
+		icon = core_tenet_assassin
+
+		name = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						religion_tag = islam_religion
+					}
+					desc = tenet_fp3_fedayeen_name
+				}
+				desc = tenet_fp3_sacred_murder_name
+			}
+		}
+
+		is_shown = { }
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pacifism_trigger
+				NOT = { doctrine:tenet_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_tenet_dharmic_pacifism_trigger
+				NOT = { doctrine:tenet_dharmic_pacifism = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = fedayeen_required_doctrines_trigger
+				OR = {
+					doctrine:tenet_warmonger = { is_in_list = selected_doctrines }
+					doctrine:tenet_unrelenting_faith = { is_in_list = selected_doctrines }
+					doctrine:tenet_consolamentum = { is_in_list = selected_doctrines }
+					doctrine:tenet_armed_pilgrimages = { is_in_list = selected_doctrines }
+					doctrine:tenet_struggle_submission = { is_in_list = selected_doctrines } 
+					doctrine:tenet_pursuit_of_power = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					AND = {
+						OR = {
+							has_doctrine = muhammad_succession_shia_doctrine
+							has_doctrine = muhammad_succession_muhakkima_doctrine
+						}
+						OR = {
+							has_doctrine = tenet_warmonger
+							has_doctrine = tenet_unrelenting_faith
+							has_doctrine = tenet_consolamentum
+						}
+					}
+
+				}
+				value = faith_tenet_cost_low
+			}
+			else = {
+				value = faith_tenet_cost_massive
+			}
+
+			# Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_fp3_fedayeen }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			master_assassin_court_position_unlocked = yes 
+			death_is_glory = yes
+			sanctioned_assassinations = yes 
+		}
+
+		character_modifier = {
+			controlled_province_advantage = 5
+			monthly_piety_gain_per_dread_add = 0.01
+			prowess = 2
+		}
+
+		traits = {
+			virtues = { vengeful = 1 }
+			sins = { craven = 1 }
+		}
+	}
+
+	tenet_communal_possessions = {
+		icon = core_tenet_communism
+		is_shown = {}
+		can_pick = {
+			always = yes
+		}
+
+		piety_cost = {
+			if = {
+				limit = {
+					OR = {
+						has_doctrine = tenet_mendicant_preachers
+						has_doctrine = tenet_gnosticism 
+						religion_tag = christianity_religion 
+						religion_tag = zoroastrianism_religion
+					}
+				}
+				value = faith_tenet_cost_mid
+			}
+			else = {
+				value = faith_tenet_cost_high 
+			}
+
+			#Multiplier for keeping same tenet
+			if = {
+				limit = { has_doctrine = tenet_communal_possessions }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			piety_from_gifts_active = yes
+			piety_from_marrying_lowborn_active = yes
+		}
+
+		character_modifier = {
+			monthly_county_control_growth_factor = -0.2
+			build_gold_cost = -0.1
+			county_opinion_add = 10 
+		}
+
+		traits = {
+			virtues = { peasant_leader = 2 } #because communism! 
+			sins = { arrogant }
+		}
+	}
+}
+
+	#############################
+	# Empty Template Tenet 		#
+	#############################
+
+	#tenets = {
+	#	is_shown = {
+	#		always = no
+	#	}
+	#	can_pick = {
+	#		always = yes
+	#	}
+
+	#	piety_cost = {
+	#		if = {
+	#			limit = {
+	#				always = no
+	#			}
+	#			value = faith_tenet_cost_low
+	#		}
+	#		else = {
+	#			value = faith_tenet_cost_massive
+	#		}
+
+	#		# Multiplier for keeping same tenet
+	#		if = {
+	#			limit = { has_doctrine = tenets }
+	#			multiply = faith_unchanged_doctrine_cost_mult
+	#		}
+	#	}
+
+	#	parameters = {
+	#		tenets_active = yes
+	#	}
+
+	#	character_modifier = {
+
+	#	}
+
+	#	traits = {
+	#		virtues = { brave = 2}
+	#		sins = { craven = 2}
+	#	}
+	#}

--- a/common/religion/doctrines/00_doctrines.txt
+++ b/common/religion/doctrines/00_doctrines.txt
@@ -1,0 +1,1412 @@
+﻿doctrine_marriage_type = {
+	group = "marriage"
+	doctrine_monogamy = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_monogamy }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			number_of_spouses = 1
+			marriage_event = yes
+		}
+	}
+
+	doctrine_polygamy = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_polygamy }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			number_of_spouses = 4
+			spouse_piety_loss = yes
+		}
+	}
+
+	doctrine_concubines = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_concubines }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			number_of_spouses = 1
+			number_of_consorts = 3
+		}
+	}
+}
+
+doctrine_divorce = {
+	group = "marriage"
+	doctrine_divorce_disallowed = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_divorce_disallowed }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_divorce_allowed }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+
+		}
+		parameters = {
+			divorce_disallowed = yes
+		}
+	}
+	doctrine_divorce_approval = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_divorce_approval }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+
+		}
+		parameters = {
+			divorce_approval = yes
+		}
+	}
+	doctrine_divorce_allowed = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_divorce_allowed }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_divorce_disallowed }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			divorce_allowed = yes
+		}
+	}
+}
+
+doctrine_bastardry = {
+	group = "marriage"
+	doctrine_bastardry_none = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_bastardry_none }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_bastardry_all }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			bastards_none = yes
+		}
+	}
+	doctrine_bastardry_legitimization = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_bastardry_legitimization }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			bastards_legitimize = yes
+		}
+	}
+	doctrine_bastardry_all = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_bastardry_all }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_bastardry_none }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			bastards_always = yes
+		}
+	}
+}
+
+doctrine_homosexuality = {
+	group = "crimes"
+	doctrine_homosexuality_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_homosexuality_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_homosexuality_accepted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			homosexuality_illegal = yes
+		}
+	}
+	doctrine_homosexuality_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_homosexuality_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			homosexuality_shunned = yes
+		}
+	}
+	doctrine_homosexuality_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_homosexuality_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_homosexuality_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			homosexuality_accepted = yes
+		}
+	}
+}
+
+doctrine_deviancy = {
+	group = "crimes"
+	doctrine_deviancy_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_deviancy_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_accepted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_virtuous }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			deviancy_illegal = yes
+		}
+	}
+	doctrine_deviancy_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_deviancy_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_virtuous }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			deviancy_shunned = yes
+		}
+	}
+	doctrine_deviancy_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_deviancy_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			deviancy_accepted = yes
+		}
+	}
+	doctrine_deviancy_virtuous = {
+		can_pick = {
+			custom_description = {
+				text = must_select_carnal_exaltation
+				doctrine:tenet_carnal_exaltation = { is_in_list = selected_doctrines }
+			}
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_massive
+			if = {
+				limit = { has_doctrine = doctrine_deviancy_virtuous }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_shunned }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_deviancy_crime }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		traits = {
+			virtues = { deviant }
+		}
+		parameters = {
+			deviancy_accepted = yes
+		}
+	}
+}
+
+doctrine_adultery_men = {
+	group = "crimes"
+	doctrine_adultery_men_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_men_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_adultery_men_accepted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			adultery_male_crime = yes
+		}
+	}
+	doctrine_adultery_men_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_men_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			adultery_male_shunned = yes
+		}
+	}
+	doctrine_adultery_men_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_men_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_adultery_men_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			adultery_male_accepted = yes
+		}
+	}
+}
+
+doctrine_adultery_women = {
+	group = "crimes"
+	doctrine_adultery_women_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_women_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_adultery_women_accepted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			adultery_female_crime = yes
+		}
+	}
+	doctrine_adultery_women_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_women_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			adultery_female_shunned = yes
+		}
+	}
+	doctrine_adultery_women_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_adultery_women_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_adultery_women_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			adultery_female_accepted = yes
+		}
+	}
+}
+
+doctrine_kinslaying = {
+	group = "crimes"
+	doctrine_kinslaying_any_dynasty_member_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_kinslaying_any_dynasty_member_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_close_kin_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_shunned }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_accepted }
+				multiply = faith_changed_doctrine_cost_mult_four_step
+			}
+		}
+		parameters = {
+			kinslaying_any_dynasty_member_crime = yes
+		}
+	}
+	doctrine_kinslaying_extended_family_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_kinslaying_extended_family_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_shunned }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_accepted }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			kinslaying_extended_family_crime = yes
+		}
+	}
+	doctrine_kinslaying_close_kin_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_kinslaying_close_kin_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_doctrine = doctrine_kinslaying_accepted
+						has_doctrine = doctrine_kinslaying_any_dynasty_member_crime
+					}
+				}
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			kinslaying_close_kin_crime = yes
+		}
+	}
+	doctrine_kinslaying_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_kinslaying_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_extended_family_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_any_dynasty_member_crime }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			kinslaying_shunned = yes
+		}
+	}
+	doctrine_kinslaying_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_kinslaying_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_close_kin_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_extended_family_crime }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_kinslaying_any_dynasty_member_crime }
+				multiply = faith_changed_doctrine_cost_mult_four_step
+			}
+
+		}
+		parameters = {
+			kinslaying_accepted = yes
+		}
+	}
+}
+
+doctrine_witchcraft = {
+	group = "crimes"
+	doctrine_witchcraft_crime = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_witchcraft_crime }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_accepted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_virtuous }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			witchcraft_illegal = yes
+		}
+	}
+	doctrine_witchcraft_shunned = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_witchcraft_shunned }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_virtuous }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			witchcraft_shunned = yes
+		}
+	}
+	doctrine_witchcraft_accepted = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_witchcraft_accepted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_crime }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			witchcraft_accepted = yes
+		}
+	}
+	doctrine_witchcraft_virtuous = {
+		piety_cost = {
+			value = faith_tenet_cost_massive
+			if = {
+				limit = { has_doctrine = doctrine_witchcraft_virtuous }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_shunned }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_witchcraft_crime }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		traits = {
+			virtues = { witch }
+		}
+		parameters = {
+			witchcraft_accepted = yes
+		}
+	}
+}
+
+
+doctrine_gender = {
+	group = "main_group"
+
+	doctrine_gender_male_dominated = {
+		is_shown = {
+			NOT = { has_game_rule = full_gender_equality }
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_gender_male_dominated }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_gender_female_dominated }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			male_dominated_law = yes
+			female_claims_are_weak = yes
+			women_cannot_inherit_implicit_claims = yes
+			women_cannot_be_granted_titles = yes
+			male_dominated_council = yes
+			combatant_must_be_male_if_no_roco = yes
+		}
+		character_modifier = {
+			name = female_ruler_male_dominant
+			opinion_of_female_rulers = -10
+		}
+
+		can_pick = {
+			NAND = {
+				exists = religious_head
+				religious_head.culture = { has_cultural_parameter = female_only_inheritance }
+			}
+		}
+	}
+	doctrine_gender_equal = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_gender_equal }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			gender_equal_law = yes
+			combatant_can_be_either_gender_if_no_roco = yes
+		}
+	}
+	doctrine_gender_female_dominated = {
+		is_shown = {
+			NOT = { has_game_rule = full_gender_equality }
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_gender_female_dominated }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_gender_male_dominated }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			female_dominated_law = yes
+			male_claims_are_weak = yes
+			men_cannot_inherit_implicit_claims = yes
+			men_cannot_be_granted_titles = yes
+			female_dominated_council = yes
+			combatant_must_be_female_if_no_roco = yes
+		}
+		character_modifier = {
+			name = male_ruler_female_dominant
+			opinion_of_male_rulers = -10
+		}
+
+		can_pick = {
+			NAND = {
+				exists = religious_head
+				religious_head.culture = { has_cultural_parameter = male_only_inheritance }
+			}
+		}
+	}
+}
+
+doctrine_consanguinity = {
+	group = "marriage"
+	doctrine_consanguinity_restricted = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_consanguinity_restricted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_unrestricted }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			consanguinity_restricted_marriage = yes
+			consanguinity_restricted_close_kin_incest = yes
+		}
+	}
+	doctrine_consanguinity_cousins = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_consanguinity_cousins }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_unrestricted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			consanguinity_cousins_marriage = yes
+			consanguinity_cousins_incest = yes
+			allows_cousin_marriage = yes
+		}
+	}
+	doctrine_consanguinity_aunt_nephew_and_uncle_niece = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_restricted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			consanguinity_aunt_nephew_and_uncle_niece_marriage = yes
+			consanguinity_aunt_nephew_and_uncle_niece_incest = yes
+			allows_cousin_marriage = yes
+			allows_aunt_nephew_and_uncle_niece_marriage = yes
+		}
+	}
+	doctrine_consanguinity_unrestricted = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_consanguinity_unrestricted }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_cousins }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_restricted }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			consanguinity_unrestricted_marriage = yes
+			consanguinity_unrestricted_incest = yes
+			allows_cousin_marriage = yes
+			allows_aunt_nephew_and_uncle_niece_marriage = yes
+			allows_unrestricted_marriage = yes
+		}
+	}
+	doctrine_consanguinity_mandatory = {
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_consanguinity_mandatory }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_unrestricted }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_cousins }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_consanguinity_restricted }
+				multiply = faith_changed_doctrine_cost_mult_three_step
+			}
+		}
+		parameters = {
+			#consanguinity_mandatory_marriage = yes
+			#consanguinity_mandatory_incest = yes
+			allows_cousin_marriage = yes
+			allows_aunt_nephew_and_uncle_niece_marriage = yes
+			allows_unrestricted_marriage = yes
+		}
+	}
+}
+
+doctrine_pluralism = {
+	group = "main_group"
+
+	doctrine_pluralism_fundamentalist = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pluralism_fundamentalist }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_pluralism_pluralistic }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			hostility_towards_us_mult = 2
+			
+			pluralism_fundamentalist_proselytization_bonus = yes
+			pluralism_fundamentalist_faction_join_chance = yes
+			pluralism_fundamentalist_vulnerable_to_heresy = yes
+			pluralism_fundamentalist_revocation_tyranny_minimal = yes
+		}
+		character_modifier = {
+			minority_different_faith_opinion = -20
+		}
+	}
+	doctrine_pluralism_righteous = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pluralism_righteous }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			hostility_towards_us_mult = 1
+			pluralism_righteous_revocation_tyranny_reduced = yes
+		}
+		character_modifier = {
+			minority_different_faith_opinion = -10
+		}
+	}
+	doctrine_pluralism_pluralistic = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pluralism_pluralistic }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_pluralism_fundamentalist }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_pentarchy_trigger
+				NOT = { doctrine:tenet_pentarchy = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			hostility_towards_us_mult = 0.5
+			pluralism_pluralistic_proselytization_penalty = yes
+			pluralism_pluralistic_faction_join_chance = yes
+			pluralism_pluralistic_resistant_to_heresy = yes
+			pluralism_pluralistic_holy_wars_preserve_vassals = yes
+			
+		}
+	}
+}
+
+doctrine_theocracy = {
+	group = "main_group"
+	doctrine_theocracy_temporal = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_theocracy_temporal }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_theocracy_lay_clergy }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		
+		can_pick = {
+			custom_description = {
+				text = incompatible_doctrine_theocracy_temporal_trigger
+				NOT = { doctrine:doctrine_temporal_head = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			theocracy_temple_lease = yes
+		}
+	}
+	doctrine_theocracy_lay_clergy = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_theocracy_lay_clergy }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_theocracy_temporal }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+
+		parameters = {
+			theocracy_temple_ownership = yes
+			lay_clergy = yes
+			allowed_holding_type_church_holding = yes
+		}
+	}
+}
+
+doctrine_head_of_faith = {
+	group = "main_group"
+
+	doctrine_no_head = {
+		visible = no
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_no_head }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			no_head_of_faith = yes
+			minimum_fervor = 25
+		}
+	}
+	doctrine_spiritual_head = {
+		visible = no
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_spiritual_head }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			spiritual_head_of_faith = yes
+			spiritual_head_of_faith_claims = yes
+			spiritual_head_of_faith_gold = yes
+		}
+	}
+	doctrine_temporal_head = {
+		visible = no
+		piety_cost = {
+			value = faith_doctrine_cost_massive
+			if = {
+				limit = { has_doctrine = doctrine_temporal_head }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		can_pick = {
+			custom_description = {
+				text = incompatible_doctrine_theocracy_temporal_trigger
+				NOT = { doctrine:doctrine_theocracy_temporal = { is_in_list = selected_doctrines } }
+			}
+			custom_description = {
+				text = incompatible_doctrine_spiritual_appointment_temporal_trigger
+				NOR = {
+					doctrine:doctrine_clerical_succession_spiritual_appointment = { is_in_list = selected_doctrines }
+					doctrine:doctrine_clerical_succession_spiritual_fixed_appointment = { is_in_list = selected_doctrines }
+				}
+			}
+		}
+
+		parameters = {
+			temporal_head_of_faith = yes
+			temporal_head_of_faith_directed_holy_wars = yes
+		}
+	}
+}
+
+doctrine_clerical_function = {
+	group = "clergy"
+	doctrine_clerical_function_taxation = {
+		clergy_modifier = {
+			#monthly_county_control_growth_add_even_if_baron = 0.2
+			monthly_county_control_growth_factor_even_if_baron = 0.2
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_function_taxation }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+	}
+	doctrine_clerical_function_alms_and_pacification = {
+		clergy_modifier = {
+			county_opinion_add_even_if_baron = 10
+			domain_tax_mult_even_if_baron = -0.05
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_function_alms_and_pacification }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+	}
+	doctrine_clerical_function_recruitment = {
+		clergy_modifier = {
+			domain_tax_same_faith_mult_even_if_baron = -0.03
+			levy_reinforcement_rate_same_faith_even_if_baron = 0.3
+			prowess = 4
+		}
+		parameters = {
+			clergy_can_fight = yes
+		}
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_function_recruitment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+	}
+}
+
+doctrine_clerical_gender = {
+	group = "clergy"
+	doctrine_clerical_gender_male_only = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_gender_male_only }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_clerical_gender_female_only }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			clergy_must_be_male = yes
+		}
+	}
+	doctrine_clerical_gender_female_only = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_gender_female_only }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_clerical_gender_male_only }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		parameters = {
+			clergy_must_be_female = yes
+		}
+	}
+	doctrine_clerical_gender_either = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_gender_either }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+
+		parameters = {
+			clergy_can_be_either_gender = yes
+		}
+	}
+}
+
+doctrine_clerical_marriage = {
+	group = "clergy"
+	doctrine_clerical_marriage_allowed = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_marriage_allowed }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_clerical_marriage_disallowed }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+		
+		parameters = {
+			clergy_can_marry = yes
+		}
+	}
+	doctrine_clerical_marriage_disallowed = {
+		piety_cost = {
+			value = faith_doctrine_cost_low
+			if = {
+				limit = { has_doctrine = doctrine_clerical_marriage_disallowed }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else_if = {
+				limit = { has_doctrine = doctrine_clerical_marriage_allowed }
+				multiply = faith_changed_doctrine_cost_mult_two_step
+			}
+		}
+
+		parameters = {
+			clergy_can_marry = no
+		}
+	}
+}
+
+doctrine_clerical_succession = {
+	group = "clergy"
+	doctrine_clerical_succession_temporal_appointment = { # Temporal, Free
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_clerical_succession_temporal_appointment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else = {
+				if = {
+					limit = {
+						OR = { # Was Spiritual
+							has_doctrine = doctrine_clerical_succession_spiritual_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_spiritual_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+				if = {
+					limit = {
+						OR = {	# Was Fixed
+							has_doctrine = doctrine_clerical_succession_spiritual_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_fixed_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+			}
+			# Round up to the nearest multiple of 25
+			divide = 25
+			ceiling = yes
+			multiply = 25
+		}
+
+		parameters = {
+			clerical_appointment_ruler = yes
+			clerical_appointment_fixed = no
+		}
+	}
+	doctrine_clerical_succession_spiritual_appointment = { # Spiritual, Free
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_clerical_succession_spiritual_appointment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else = {
+				if = {
+					limit = {
+						OR = { # Was Temporal
+							has_doctrine = doctrine_clerical_succession_temporal_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+				if = {
+					limit = {
+						OR = {	# Was Fixed
+							has_doctrine = doctrine_clerical_succession_spiritual_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_fixed_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}	
+			}
+			# Round up to the nearest multiple of 25
+			divide = 25
+			ceiling = yes
+			multiply = 25
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_doctrine_spiritual_appointment_temporal_trigger
+				NOT = { doctrine:doctrine_temporal_head = { is_in_list = selected_doctrines } }
+			}
+		}		
+
+		parameters = {
+			clerical_appointment_head_of_faith = yes
+			clerical_appointment_fixed = no
+		}
+	}
+	doctrine_clerical_succession_temporal_fixed_appointment = { # Temporal, Fixed
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_clerical_succession_temporal_fixed_appointment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else = {
+				if = {
+					limit = {
+						OR = { # Was Spiritual
+							has_doctrine = doctrine_clerical_succession_spiritual_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_spiritual_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+				if = {
+					limit = {
+						OR = {	# Was free
+							has_doctrine = doctrine_clerical_succession_spiritual_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+			}
+			# Round up to the nearest multiple of 25
+			divide = 25
+			ceiling = yes
+			multiply = 25
+		}
+		parameters = {
+			clerical_appointment_ruler = yes
+			clerical_appointment_fixed = yes
+		}
+	}
+	doctrine_clerical_succession_spiritual_fixed_appointment = { # Spiritual, Fixed
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_clerical_succession_spiritual_fixed_appointment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+			else = {
+				if = {
+					limit = {
+						OR = { # Was Temporal
+							has_doctrine = doctrine_clerical_succession_temporal_fixed_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+				if = {
+					limit = {
+						OR = {	# Was Free
+							has_doctrine = doctrine_clerical_succession_spiritual_appointment
+							has_doctrine = doctrine_clerical_succession_temporal_appointment
+						}
+					}
+					multiply = faith_changed_doctrine_cost_mult_two_step
+				}
+			}
+			# Round up to the nearest multiple of 25
+			divide = 25
+			ceiling = yes
+			multiply = 25
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_doctrine_spiritual_appointment_temporal_trigger
+				NOT = { doctrine:doctrine_temporal_head = { is_in_list = selected_doctrines } }
+			}
+		}
+
+		parameters = {
+			clerical_appointment_head_of_faith = yes
+			clerical_appointment_fixed = yes
+		}
+	}
+}
+
+doctrine_pilgrimage = {
+	group = "main_group"
+	doctrine_pilgrimage_forbidden = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pilgrimage_forbidden }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		character_modifier = {
+			monthly_piety_gain_mult = 0.2
+			advantage_against_coreligionists = 5
+		}
+		parameters = {
+			forbidden_from_pilgrimage = yes
+		}
+		traits = {
+			sins = { hajjaj pilgrim }
+		}
+	}
+
+	doctrine_pilgrimage_encouraged = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pilgrimage_encouraged }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			can_go_on_pilgrimage = yes
+			basic_pilgrimage_rewards = yes
+		}
+	}
+
+	doctrine_pilgrimage_mandatory = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pilgrimage_mandatory }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		is_shown = {
+			NOT = { religion_tag = islam_religion }
+		}
+		character_modifier = {
+			monthly_piety_gain_mult = -0.25
+			same_faith_opinion = -5
+		}
+		parameters = {
+			can_go_on_pilgrimage = yes
+			mandatory_pilgrimage = yes
+			basic_pilgrimage_rewards = yes
+		}
+	}
+
+	doctrine_pilgrimage_mandatory_hajj = {
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_pilgrimage_mandatory_hajj }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		is_shown = {
+			religion_tag = islam_religion
+		}
+		character_modifier = {
+			monthly_piety_gain_mult = -0.25
+			same_faith_opinion = -5
+		}
+		parameters = {
+			can_go_on_pilgrimage = yes
+			mandatory_hajj = yes
+			basic_pilgrimage_rewards = yes
+		}
+	}
+}
+
+doctrine_funeral = {
+	group = "clergy"
+	doctrine_funeral_stoic = { # Abrahamic funerals, stand around and try not to cry too much before the body is humbly buried
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_funeral_stoic }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			burial_funeral = yes
+			stoic_funeral = yes
+		}
+	}
+	doctrine_funeral_bewailment = { # West African funerals, strongly encouraged to show emotion before the body is humbly buried
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_funeral_bewailment }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			burial_funeral = yes
+			bewailment_funeral = yes
+		}
+	}
+	doctrine_funeral_cremation = { # Catch-all cremations, burn or otherwise dissolve the body
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_funeral_cremation }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			cremation_funeral = yes
+		}
+	}
+	doctrine_funeral_sky_burial = { # Have the body fed to scavenging animals and birds
+		piety_cost = {
+			value = faith_doctrine_cost_mid
+			if = {
+				limit = { has_doctrine = doctrine_funeral_sky_burial }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			sky_burials_active = yes
+			can_build_towers_of_silence_active = yes
+		}
+
+		character_modifier = {
+			negate_health_penalty_add = 0.25
+		}
+	}
+	doctrine_funeral_mummification = { # Fanatically preserve the body, very expensive
+		piety_cost = {
+			value = faith_doctrine_cost_high
+			if = {
+				limit = { has_doctrine = doctrine_funeral_mummification }
+				multiply = faith_unchanged_doctrine_cost_mult
+			}
+		}
+		parameters = {
+			mummification_funeral = yes
+		}
+
+		can_pick = {
+			custom_description = {
+				text = incompatible_tenet_aniconism_trigger
+				NOT = { doctrine:tenet_aniconism = { is_in_list = selected_doctrines } }
+			}
+		}
+	}
+}

--- a/common/scripted_triggers/00_religious_triggers.txt
+++ b/common/scripted_triggers/00_religious_triggers.txt
@@ -1,0 +1,1759 @@
+﻿
+###TRIGGER LIST
+
+# has_strong_religious_conviction_trigger
+# is_christian_trigger
+
+###DOCTRINE BASED###
+# is_weak_claimant_due_to_gender_trigger
+# can_be_combatant_based_on_gender_trigger
+# can_be_clergy_due_to_gender_trigger
+# faith_is_aniconic_trigger
+# relation_with_character_is_incestuous_in_faith_trigger 	- Relation would be shunned in faith
+# relation_with_character_is_incestuous_in_my_faith_trigger 			- Relation would be shunned in the faith of character you use trigger in
+# relation_with_character_is_incestuous_in_my_or_lieges_faith_trigger - Relation would be shunned in the faith of the character you use trigger in or their liege's faith
+# faith_allows_marriage_consanguinity_trigger
+# relation_with_character_is_sodomy_in_faith_trigger
+# relation_with_character_is_sodomy_trigger
+# relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger
+# trait_is_shunned_in_faith_trigger
+# trait_is_criminal_in_faith_trigger
+# trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger
+# has_negative_attitude_towards_trait_trigger
+# secret_is_shunned_in_faith_trigger
+# secret_is_criminal_in_faith_trigger
+# secret_is_shunned_or_criminal_in_my_or_lieges_faith_trigger
+# religion_has_angels_trigger
+# highgod_is_passive_trigger
+# highgod_is_active_trigger
+# is_reincarnation_trigger
+# holy_order_1000_request_target_trigger 		- Is this ruler a valid target for a holy order to request land from?
+
+###HERESY TRIGGERS###
+# is_valid_heresiarch
+
+###RELIGIOUS INTERACTIONS###
+# can_take_religious_vows_trigger
+
+
+# CHECK A NUMBER OF RELIGION-RELATED CONDITIONS TO DETERMINE HOW STRONG OF A BELIEVER THEY SEEM TO BE
+has_strong_religious_conviction_trigger = {
+	NOR = {
+		has_trait = cynical
+		has_trait = excommunicated
+	}
+	OR = {
+		has_trait = zealous
+		has_trait = pilgrim
+		has_trait = devoted
+		has_trait = sayyid
+		has_trait = saoshyant
+		has_trait = savior
+		has_trait = divine_blood
+		has_trait = blood_of_prophet
+		has_trait = faith_warrior
+		has_trait = saint
+	}
+}
+
+is_christian_trigger = {
+	OR = {
+		faith = { religion_tag = christianity_religion }
+	}
+}
+
+# Not-non-XYZ triggers allow us to check for specific historical faiths whilst still defaulting to something positive for variant faiths.
+## E.g., looking to see if something would only be of interest to Catholics, but if we're dealing with a player-made heresy, still return true. This way mechanics will default to on rather than off (still likely to result in weird GHWs, but at least less random ones).
+not_non_catholic_standard_christian_faith_trigger = {
+	NOR = {
+		this = faith:orthodox
+		this = faith:iconoclast
+		this = faith:coptic
+		this = faith:armenian_apostolic
+	}
+}
+
+not_non_orthodox_standard_christian_faith_trigger = {
+	NOR = {
+		this = faith:catholic
+		this = faith:coptic
+		this = faith:armenian_apostolic
+	}
+}
+
+not_non_coptic_standard_christian_faith_trigger = {
+	NOR = {
+		this = faith:catholic
+		this = faith:orthodox
+		this = faith:iconoclast
+		this = faith:armenian_apostolic
+	}
+}
+
+not_non_armenian_standard_christian_faith_trigger = {
+	NOR = {
+		this = faith:catholic
+		this = faith:orthodox
+		this = faith:iconoclast
+		this = faith:coptic
+	}
+}
+
+is_weak_claimant_due_to_gender_trigger = {
+	OR = {
+		AND = {
+			$FAITH$ = { has_doctrine_parameter = female_claims_are_weak }
+			$CHARACTER$ = { is_female = yes }
+		}
+		AND = {
+			$FAITH$ = { has_doctrine_parameter = male_claims_are_weak }
+			$CHARACTER$ = { is_male = yes }
+		}
+	}
+}
+
+can_be_combatant_based_on_gender_trigger = {
+	custom_description = {
+		text = "can_be_combatant_based_on_gender"
+		object = this
+		subject = $ARMY_OWNER$
+		# Priests only fight if faith has war priests
+		trigger_if = {
+			limit = {
+				OR = {
+					has_trait = devoted
+					is_clergy = yes
+				}
+			}
+			OR = {
+				faith = { has_doctrine_parameter = clergy_can_fight }
+				culture = { has_cultural_parameter = culture_clergy_can_fight }
+				AND = {
+					$ARMY_OWNER$.culture = {
+						has_cultural_parameter = high_prowess_ignores_knight_restrictions
+					}
+					prowess >= 10
+				}
+			}
+		}
+		OR = {
+			trigger_if = { # Has the Royal Court and thus can modify pillars
+				limit = {
+					has_dlc_feature = diverge_culture # Can modify pillars
+				}
+				OR = {
+					$ARMY_OWNER$ = { culture = { has_cultural_parameter = martial_custom_equal_combatant } }
+					AND = {
+						$ARMY_OWNER$ = { culture = { has_cultural_parameter = martial_custom_male_only_combatant } }
+						is_male = yes
+					}
+					AND = {
+						$ARMY_OWNER$ = { culture = { has_cultural_parameter = martial_custom_female_only_combatant } }
+						is_female = yes
+					}
+				}
+				
+			}
+			trigger_else = { # Does not have the Royal Court and thus combatant is governed by faith
+				OR = {
+					$ARMY_OWNER$ = { faith = { has_doctrine_parameter = combatant_can_be_either_gender_if_no_roco } }
+					AND = {
+						$ARMY_OWNER$ = { faith = { has_doctrine_parameter = combatant_must_be_male_if_no_roco } }
+						is_male = yes
+					}
+					AND = {
+						$ARMY_OWNER$ = { faith = { has_doctrine_parameter = combatant_must_be_female_if_no_roco } }
+						is_female = yes
+					}
+				}
+			}
+			AND = {
+				$ARMY_OWNER$ = {
+					culture = { has_cultural_parameter = has_access_to_shieldmaidens }
+				}
+				# No need to gender diversify this: if they're a right-gender shieldperson of the culture, then they've already got permission to fight from the previous AND conditions.
+				has_trait = shieldmaiden
+			}
+			# Event-based special exceptions
+			has_character_modifier = ignores_gender_army_rules
+			AND = {
+				$ARMY_OWNER$ = { culture = { has_cultural_parameter = high_prowess_ignores_knight_restrictions } }
+				NOT = { $ARMY_OWNER$ = { culture = { has_cultural_parameter = minimum_prowess_for_knights } } }
+				prowess >= 10
+			}
+			AND = {
+				$ARMY_OWNER$ = {
+					culture = {
+						has_cultural_parameter = high_prowess_ignores_knight_restrictions
+						has_cultural_parameter = minimum_prowess_for_knights
+					}
+				}
+				prowess >= 12
+			}
+		}
+	}
+}
+
+can_be_clergy_due_to_gender_trigger = {
+	OR = {
+		AND = {
+			faith = { has_doctrine_parameter = clergy_must_be_female }
+			is_female = yes
+		}
+		AND = {
+			faith = { has_doctrine_parameter = clergy_must_be_male }
+			is_male = yes
+		}
+		faith = { has_doctrine_parameter = clergy_can_be_either_gender }
+	}
+}
+
+is_wrong_gender_in_faith_trigger = {
+	OR = {
+		AND = {
+			is_female = yes
+			$FAITH$ = { has_doctrine_parameter = male_dominated_law }
+		}
+		AND = {
+			is_male = yes
+			$FAITH$ = { has_doctrine_parameter = female_dominated_law }
+		}
+	}
+}
+
+faith_is_aniconic_trigger = {
+	faith = {
+		OR = {	
+			religion = religion:islam_religion
+			has_doctrine = tenet_aniconism
+		}
+	}
+}
+
+#Needs CHARACTER and FAITH
+relation_with_character_is_incestuous_in_faith_trigger = {
+	OR = {
+		#doctrine_consanguinity_restricted; absolutely no family business 
+		AND = {
+			$FAITH$ = { has_doctrine = doctrine_consanguinity_restricted }
+			is_close_or_extended_family_of = $CHARACTER$ #[parents, children, siblings, grandparents, grandchildren, cousins, uncles, aunts, nephews, nieces]
+		}
+		#doctrine_consanguinity_cousins; the only acceptable incest is with your cousin
+		AND = {
+			$FAITH$ = { has_doctrine = doctrine_consanguinity_cousins }
+			OR = {
+	            is_close_family_of = $CHARACTER$ #[parents, children, siblings, grandparents, grandchildren]
+	            is_uncle_or_aunt_of = $CHARACTER$
+	            is_nibling_of = $CHARACTER$
+	        }
+		}
+		#doctrine_consanguinity_aunt_nephew_and_uncle_niece; extended family is ok
+		AND = {
+			$FAITH$ = { has_doctrine = doctrine_consanguinity_aunt_nephew_and_uncle_niece }	
+			is_close_family_of = $CHARACTER$
+		}
+		#doctrine_consanguinity_unrestricted; all forms of incest is acceptable
+	}	
+}
+
+#Note: only checks from the viewpoint of current scope. Needs CHARACTER
+relation_with_character_is_incestuous_in_my_faith_trigger = {
+	faith = { save_temporary_scope_as = my_faith }
+	relation_with_character_is_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:my_faith }
+}
+
+relation_with_character_is_incestuous_in_my_or_lieges_faith_trigger = {
+	OR = {
+		AND = {
+			faith = { #My faith doesn't approve
+				save_temporary_scope_as = check_faith
+			}
+			relation_with_character_is_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+		}
+		AND = { #Liege's faith doesn't approve
+			exists = liege
+			liege = {
+				faith = {
+					save_temporary_scope_as = check_faith
+				}
+			}
+			relation_with_character_is_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+		}
+	}
+}
+
+#Needs CHARACTER_1 and CHARACTER_2
+faith_allows_marriage_consanguinity_trigger = {
+	save_temporary_scope_as = consanguinity_faith
+
+	NOT = {
+		OR = {
+			$CHARACTER_1$ = {
+				relation_with_character_is_incestuous_in_faith_trigger = {
+					CHARACTER = $CHARACTER_2$
+					FAITH = scope:consanguinity_faith
+				}
+			}
+			$CHARACTER_1$ = {
+				relation_with_character_is_not_incestuous_in_faith_trigger = {
+					CHARACTER = $CHARACTER_2$
+					FAITH = scope:consanguinity_faith
+				}
+			}
+		}
+	}
+}
+relation_between_characters_is_sodomy_in_my_faith_trigger = {
+	$CHARACTER_1$ = { is_male = yes }
+	$CHARACTER_2$ = { is_male = yes }
+	faith = { 
+		OR = {
+			has_doctrine_parameter = homosexuality_shunned 
+			has_doctrine_parameter = homosexuality_illegal
+		}
+	}
+}
+
+relation_with_character_is_sodomy_in_faith_trigger = {
+	is_male = yes
+	$CHARACTER$ = { is_male = yes }
+	$FAITH$ = {
+		OR = {
+			has_doctrine_parameter = homosexuality_shunned
+			has_doctrine_parameter = homosexuality_illegal
+		}
+	}
+}
+
+#Note: only checks from the viewpoint of current scope. Needs CHARACTER
+relation_with_character_is_sodomy_trigger = {
+	faith = { save_temporary_scope_as = my_faith }
+	relation_with_character_is_sodomy_in_faith_trigger = {
+		CHARACTER = $CHARACTER$
+		FAITH = scope:my_faith
+	}
+}
+
+relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger = {
+	OR = {
+		AND = {
+			faith = { #My faith doesn't approve
+				save_temporary_scope_as = check_faith
+			}
+			relation_with_character_is_sodomy_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+		}
+		AND = { #Liege's faith doesn't approve
+			exists = liege
+			liege = {
+				faith = {
+					save_temporary_scope_as = check_faith
+				}
+			}
+			relation_with_character_is_sodomy_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+		}
+	}
+}
+
+murdering_character_is_kinslaying_in_faith_trigger = {
+	OR = {
+		is_close_or_extended_family_of = $CHARACTER$
+		dynasty = $CHARACTER$.dynasty
+	}
+	$FAITH$ = { NOT = { has_doctrine = doctrine_kinslaying_accepted } }
+}
+
+murdering_character_is_kinslaying_in_my_or_same_dynasty_lieges_faith_trigger = {
+	save_temporary_scope_as = kinslayer_me
+	faith = {
+		save_temporary_scope_as = check_faith
+	}
+	trigger_if = {
+		limit = {
+			exists = liege
+			liege = { dynasty = scope:kinslayer_me.dynasty }
+		}
+		liege = {
+			faith = {
+				save_temporary_scope_as = check_faith_liege
+			}
+		}
+	}
+	OR = {
+		murdering_character_is_kinslaying_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith } #My faith doesn't approve
+		AND = { #Liege's faith doesn't approve
+			exists = liege
+			liege = { dynasty = scope:kinslayer_me.dynasty }
+			murdering_character_is_kinslaying_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith_liege }
+		}
+	}
+}
+
+
+
+trait_is_shunned_in_faith_trigger = {
+	save_temporary_scope_value_as = {
+		name = shunned_trait_check
+		value = flag:$TRAIT$
+	}
+	OR = {
+		#INCEST
+		AND = {
+			scope:shunned_trait_check = flag:incestuous
+			$FAITH$ = { NOT = { has_doctrine_parameter = allows_unrestricted_marriage } }
+		}
+		#WITCH
+		AND = {
+			scope:shunned_trait_check = flag:witch	
+			$FAITH$ = { has_doctrine_parameter = witchcraft_shunned }
+		}
+		#SODOMITE
+		AND = {
+			scope:shunned_trait_check = flag:sodomite
+			$FAITH$ = { has_doctrine_parameter = homosexuality_shunned }
+		}
+		#DEVIANT
+		AND = {
+			scope:shunned_trait_check = flag:deviant
+			$FAITH$ = { has_doctrine_parameter = deviancy_shunned }
+		}
+		#ADULTERER/FORNICATOR
+		AND = {
+			OR = {
+				scope:shunned_trait_check = flag:adulterer
+				scope:shunned_trait_check = flag:fornicator
+			}
+			OR = {
+				AND = {
+					$FAITH$ = { has_doctrine_parameter = adultery_female_shunned }
+					$GENDER_CHARACTER$ = { is_female = yes }
+				}
+				AND = {
+					$FAITH$ = { has_doctrine_parameter = adultery_male_shunned }
+					$GENDER_CHARACTER$ = { is_male = yes }
+				}
+			}
+		}
+		#KINSLAYER
+		AND = {
+			OR = {
+				scope:shunned_trait_check = flag:kinslayer_1
+				scope:shunned_trait_check = flag:kinslayer_2
+				scope:shunned_trait_check = flag:kinslayer_3
+			}
+			$FAITH$ = { has_doctrine_parameter = kinslaying_shunned }
+		}
+	}
+}
+
+trait_is_criminal_in_faith_trigger = {
+	save_temporary_scope_value_as = {
+		name = criminal_trait_check
+		value = flag:$TRAIT$
+	}
+	OR = {
+		#KINSLAYER
+		AND = {
+			OR = {
+				scope:criminal_trait_check = flag:kinslayer_3
+				scope:criminal_trait_check = flag:kinslayer_2
+				scope:criminal_trait_check = flag:kinslayer_1
+			}
+			$FAITH$ = { has_doctrine_parameter = kinslaying_any_dynasty_member_crime }
+		}
+		AND = {
+			OR = {
+				scope:criminal_trait_check = flag:kinslayer_3
+				scope:criminal_trait_check = flag:kinslayer_2
+			}
+			$FAITH$ = { has_doctrine_parameter = kinslaying_extended_family_crime }
+		}
+		AND = {
+			scope:criminal_trait_check = flag:kinslayer_3
+			$FAITH$ = { has_doctrine_parameter = kinslaying_close_kin_crime }
+		}
+		#WITCH
+		AND = {
+			scope:criminal_trait_check = flag:witch
+			$FAITH$ = { has_doctrine_parameter = witchcraft_illegal }
+		}
+		#CANNIBAL
+		AND = {
+			scope:criminal_trait_check = flag:cannibal
+			NOT = {
+				$FAITH$ = { has_doctrine_parameter = cannibalism_legal }
+			}
+		}
+		#SODOMITE
+		AND = {
+			scope:criminal_trait_check = flag:sodomite
+			$FAITH$ = { has_doctrine_parameter = homosexuality_illegal }
+		}
+		#DEVIANT
+		AND = {
+			scope:criminal_trait_check = flag:deviant
+			$FAITH$ = { has_doctrine_parameter = deviancy_illegal }
+		}
+		#INCEST
+		AND = {
+			scope:criminal_trait_check = flag:incestuous
+			$FAITH$ = { NOT = { has_doctrine_parameter = consanguinity_unrestricted_incest } }
+		}
+		#ADULTERER/FORNICATOR
+		AND = {
+			OR = {
+				scope:criminal_trait_check = flag:adulterer
+				scope:criminal_trait_check = flag:fornicator
+			}
+			OR = {
+				AND = {
+					$FAITH$ = { has_doctrine_parameter = adultery_female_crime }
+					$GENDER_CHARACTER$ = { is_female = yes }
+				}
+				AND = {
+					$FAITH$ = { has_doctrine_parameter = adultery_male_crime }
+					$GENDER_CHARACTER$ = { is_male = yes }
+				}
+			}
+		}
+	}	
+}
+
+trait_is_shunned_or_criminal_in_faith_trigger = {
+	OR = {
+		trait_is_shunned_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = $FAITH$ GENDER_CHARACTER = $GENDER_CHARACTER$ }
+		trait_is_criminal_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = $FAITH$ GENDER_CHARACTER = $GENDER_CHARACTER$ }
+	}
+}
+
+trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = {
+	OR = {
+		AND = {
+			faith = { #My faith doesn't approve
+				save_temporary_scope_as = check_faith
+			}
+			trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:check_faith GENDER_CHARACTER = $GENDER_CHARACTER$ }
+		}
+		AND = { #Liege's faith doesn't approve
+			exists = liege
+			liege = {
+				faith = {
+					save_temporary_scope_as = check_faith
+				}
+			}
+			trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:check_faith GENDER_CHARACTER = $GENDER_CHARACTER$ }
+		}
+	}
+}
+
+has_any_shunned_or_criminal_trait_in_faith_trigger = {
+	$CHARACTER$ = {
+		OR = {
+			#KINSLAYER
+			AND = {
+				has_trait = kinslayer_3
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = kinslayer_3 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = kinslayer_2
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = kinslayer_2 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = kinslayer_1
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = kinslayer_1 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#WITCH
+			AND = {
+				has_trait = witch
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = witch FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#CANNIBAL
+			AND = {
+				has_trait = cannibal
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = cannibal FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#SODOMITE
+			AND = {
+				has_trait = sodomite
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = sodomite FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#DEVIANT
+			AND = {
+				has_trait = deviant
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = deviant FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = incestuous
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = incestuous FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#ADULTERER/FORNICATOR
+			AND = {
+				has_trait = adulterer
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = adulterer FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = fornicator
+				trait_is_shunned_or_criminal_in_faith_trigger = { TRAIT = fornicator FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+		}
+	}
+}
+
+has_any_criminal_trait_in_faith_trigger = {
+	$CHARACTER$ = {
+		OR = {
+			#KINSLAYER
+			AND = {
+				has_trait = kinslayer_3
+				trait_is_criminal_in_faith_trigger = { TRAIT = kinslayer_3 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = kinslayer_2
+				trait_is_criminal_in_faith_trigger = { TRAIT = kinslayer_2 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = kinslayer_1
+				trait_is_criminal_in_faith_trigger = { TRAIT = kinslayer_1 FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#WITCH
+			AND = {
+				has_trait = witch
+				trait_is_criminal_in_faith_trigger = { TRAIT = witch FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#CANNIBAL
+			AND = {
+				has_trait = cannibal
+				trait_is_criminal_in_faith_trigger = { TRAIT = cannibal FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#SODOMITE
+			AND = {
+				has_trait = sodomite
+				trait_is_criminal_in_faith_trigger = { TRAIT = sodomite FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#DEVIANT
+			AND = {
+				has_trait = deviant
+				trait_is_criminal_in_faith_trigger = { TRAIT = deviant FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = incestuous
+				trait_is_criminal_in_faith_trigger = { TRAIT = incestuous FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			#ADULTERER/FORNICATOR
+			AND = {
+				has_trait = adulterer
+				trait_is_criminal_in_faith_trigger = { TRAIT = adulterer FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+			AND = {
+				has_trait = fornicator
+				trait_is_criminal_in_faith_trigger = { TRAIT = fornicator FAITH = $FAITH$ GENDER_CHARACTER = $CHARACTER$ }
+			}
+		}
+	}
+}
+
+
+has_negative_attitude_towards_trait_trigger = {
+	save_temporary_scope_value_as = {
+		name = negative_status_check
+		value = flag:$TRAIT$
+	}
+
+	NOR = {
+		has_trait = $TRAIT$
+		#INCESTUOUS
+		AND = {
+			scope:negative_status_check = flag:incestuous
+			any_secret = { secret_type = secret_incest }
+		}
+		#WITCH
+		AND = {
+			scope:negative_status_check = flag:witch
+			any_secret = { secret_type = secret_witch }
+		}
+		#CANNIBAL
+		AND = {
+			scope:negative_status_check = flag:cannibal
+			any_secret = { secret_type = secret_cannibal }
+		}
+		#SODOMITE
+		AND = {
+			scope:negative_status_check = flag:sodomite
+			OR = {
+				has_sexuality = homosexual
+				has_sexuality = bisexual
+			}
+			any_secret = {
+				secret_type = secret_homosexual
+			}
+		}
+		#ADULTERER
+		AND = {
+			scope:negative_status_check = flag:adulterer
+			OR = {
+				has_trait = lustful
+				AND = {
+					is_married = yes
+					any_relation = { type = lover NOT = { is_spouse_of = prev } }
+				}
+				any_relation = {
+					type = lover
+					is_married = yes
+					NOT = { is_spouse_of = prev }
+				}
+			}
+		}
+		#FORNICATOR
+		AND = {
+			scope:negative_status_check = flag:fornicator
+			OR = {
+				has_trait = lustful
+				any_relation = { type = lover always = yes }
+			}
+		}
+	}
+
+	faith = { save_temporary_scope_as = my_faith }
+	OR = {
+		trait_is_shunned_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:my_faith GENDER_CHARACTER = $GENDER_CHARACTER$ }
+		trait_is_criminal_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:my_faith GENDER_CHARACTER = $GENDER_CHARACTER$ }
+	}
+}
+
+has_followers_trigger = {
+	OR = {
+		num_character_followers >= 1
+		num_county_followers >= 1
+	}
+}
+
+secret_is_blackmailable_trigger = {
+	OR = {
+		secret_is_blackmailable_strong_hook_trigger = { TARGET = $TARGET$ }
+		secret_is_blackmailable_weak_hook_trigger = { TARGET = $TARGET$ }
+	}
+}
+
+
+###################
+# Heresy Triggers #
+###################
+
+is_preferred_heresy = {
+	is_valid_heresy = {
+		ORIGIN_FAITH = $ORIGIN_FAITH$
+		HERETICAL_FAITH = $HERETICAL_FAITH$
+	}
+
+	OR = {
+		#If we're Chistian, pick a heretical faiths which is in the same regional group as our origin faith (i.e., Lollards for Catholics, Iconoclasts for Orthodox, etc.)
+		AND = {
+			religion_tag = christianity_religion
+			OR = {
+				faiths_are_in_western_christianity_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$ }
+				faiths_are_in_orthodox_christianity_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$ }
+				faiths_are_in_eastern_christianity_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$ }
+			}
+		}
+
+		#If we're Muslim, we want to stay within our 'branch' of Islam:
+		AND = {
+			religion_tag = islam_religion
+			OR = {
+				faiths_are_in_sunni_islam_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$}
+				faiths_are_in_shia_islam_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$}
+				faiths_are_in_muhakkima_islam_group = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$}
+			}
+		}
+		#If we're Zoroastrian, we don't want Sogdian faith in Armenia and vice versa 
+		AND = {
+			religion_tag = zoroastrianism_religion
+			OR = {
+				faiths_are_eastern_zoroastrian = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$}
+				faiths_are_western_zoroastrian = {FAITH_1 = $ORIGIN_FAITH$ FAITH_2 = $HERETICAL_FAITH$}
+			}
+		}
+
+		#Otherwise, we don't have any special preferences.
+		AND = {
+			NOT = {
+				religion_tag = islam_religion
+				religion_tag = christianity_religion
+				religion_tag = zoroastrianism_religion
+			}
+		}
+	}
+}
+
+is_valid_heresy = {
+	#The origin faith can never be its own heresy.
+	NOT = { $ORIGIN_FAITH$ = $HERETICAL_FAITH$ }
+	#Must not be considered invalid
+	invalid_for_heresy_events = no
+	# A heretical faith can't be currently locked off via variable.
+	$HERETICAL_FAITH$ = {
+		NOR = {
+			has_variable = block_conversion_till_decision_taken
+			has_variable = block_conversion_till_nebulous_circumstances
+		}
+	}
+	#Depending on the origin faith's religion/religion group, there may have additional requirements for a heresy to be considered valid.
+	OR = {
+		#For Christian Faiths, the origin and heretical faiths must not both be Ecumenical (excepting the faiths which aren't technically ecumenical).
+		AND = {
+			religion_tag = christianity_religion
+			NAND = {
+				$ORIGIN_FAITH$ = {
+					has_doctrine = special_doctrine_ecumenical_christian
+					OR = {
+						this = faith:insular_celtic
+						this = faith:bosnian_church
+						this = faith:mozarabic_church
+					}
+				}
+				$HERETICAL_FAITH$ = {
+					has_doctrine = special_doctrine_ecumenical_christian
+					OR = {
+						this = faith:insular_celtic
+						this = faith:bosnian_church
+						this = faith:mozarabic_church
+					}
+				}
+			}
+		}
+		AND = { #FP3: for Zoroastrianism, Bedhin faiths are never heresies of each other 
+			religion_tag = zoroastrianism_religion
+			NAND = {
+				$ORIGIN_FAITH$ = {
+					has_doctrine = doctrine_major_branch_behdin
+				}
+				$HERETICAL_FAITH$ = {
+					has_doctrine = doctrine_major_branch_behdin
+				}
+			}
+		}
+		#No special requirements for Muslims, Jews, or Yazidis
+		religion_tag = islam_religion
+		religion_tag = judaism_religion
+		#Eastern Faiths can shift and spread amongst each other.
+		AND = {
+			OR = {
+				religion_tag = buddhism_religion
+				religion_tag = hinduism_religion
+				religion_tag = jainism_religion
+				religion_tag = dualism_religion
+			}
+		}
+		#No special requirements for Pagan religions.
+		has_doctrine = pagan_hostility_doctrine
+	}
+}
+
+is_valid_heresiarch = {
+	faith = root
+	OR = {
+		highest_held_title_tier = tier_duchy
+		highest_held_title_tier = tier_county
+	}
+	is_imprisoned = no
+	is_capable_adult_ai = yes
+	is_landed = yes
+	exists = capital_county
+	NOT = { has_trait = heresiarch }
+	no_heretical_hof_faith_trigger = yes
+	recently_converted_faith_trigger = no # As amusing as it may be, rulers shouldn't 'flip-flop' between Faiths, so we need to enforce a cooldown on heresy conversions.
+}
+
+no_heretical_hof_faith_trigger = { #Head of Faith shouldn't convert.
+	OR = {
+		NOT = { exists = root.religious_head }
+		AND = {
+			exists = root.religious_head
+			NOT = { this = root.religious_head }
+		}
+	}
+}
+
+#Christian Heresy Groups
+faiths_are_in_western_christianity_group = {
+	OR = {
+		$FAITH_1$ = faith:catholic
+		$FAITH_1$ = faith:cathar
+		$FAITH_1$ = faith:waldensian
+		$FAITH_1$ = faith:lollard
+		AND = {
+			$FAITH_1$ = faith:insular_celtic
+			scope:heretic_capital.title_province = { geographical_region = world_europe_west_britannia }
+		}
+		AND = {
+			$FAITH_1$ = faith:mozarabic_church
+			scope:heretic_capital.title_province = { geographical_region = world_europe_west_iberia }
+		}
+	}
+	OR = {
+		$FAITH_2$ = faith:catholic
+		$FAITH_2$ = faith:cathar
+		$FAITH_2$ = faith:waldensian
+		$FAITH_2$ = faith:lollard
+		$FAITH_2$ = faith:priscillianism
+		AND = {
+			$FAITH_2$ = faith:insular_celtic
+			scope:heretic_capital.title_province = { geographical_region = world_europe_west_britannia }
+		}
+		AND = {
+			$FAITH_2$ = faith:mozarabic_church
+			scope:heretic_capital.title_province = { geographical_region = world_europe_west_iberia }
+		}
+	}
+}
+
+faiths_are_in_orthodox_christianity_group = {
+	OR = {
+		$FAITH_1$ = faith:orthodox
+		$FAITH_1$ = faith:iconoclast
+		$FAITH_1$ = faith:bogomilist
+		$FAITH_1$ = faith:paulician
+		AND = {
+			$FAITH_1$ = faith:bosnian_church
+			scope:heretic_capital.title_province = { geographical_region = world_europe_south_east }
+		}
+	}
+	OR = {
+		$FAITH_2$ = faith:orthodox
+		$FAITH_2$ = faith:iconoclast
+		$FAITH_2$ = faith:bogomilist
+		$FAITH_2$ = faith:paulician
+		$FAITH_2$ = faith:bosnian_church
+		$FAITH_2$ = faith:cainitism
+		AND = {
+			$FAITH_1$ = faith:bosnian_church
+			scope:heretic_capital.title_province = { geographical_region = world_europe_south_east }
+		}
+	}
+}
+
+faiths_are_in_eastern_christianity_group = {
+	OR = {
+		$FAITH_1$ = faith:coptic
+		$FAITH_1$ = faith:armenian_apostolic
+		$FAITH_1$ = faith:nestorian
+		$FAITH_1$ = faith:messalian
+		$FAITH_1$ = faith:paulician
+	}
+	OR = {
+		$FAITH_2$ = faith:coptic
+		$FAITH_2$ = faith:armenian_apostolic
+		$FAITH_2$ = faith:nestorian
+		$FAITH_2$ = faith:messalian
+		$FAITH_2$ = faith:paulician
+		$FAITH_2$ = faith:mandeaism
+	}
+}
+
+faiths_are_shia_zandaqa_sub_group = {
+	OR = {
+		this = faith:quranist
+		this = faith:qarmatian
+		this = faith:ghulat
+		this = faith:alawite
+		this = faith:alevi
+		this = faith:druze
+	}
+}
+
+faiths_are_in_sunni_islam_group = {
+	$FAITH_1$ = {
+		has_doctrine = muhammad_succession_sunni_doctrine
+	}
+	$FAITH_2$ = {
+		OR = {
+			has_doctrine = muhammad_succession_sunni_doctrine
+			has_doctrine = muhammad_succession_muhakkima_doctrine
+			this = faith:sabianism
+			this = faith:manichean
+			this = faith:quranist
+		}
+	}
+}
+
+faiths_are_in_shia_islam_group = {
+	$FAITH_1$ = {
+		OR = {
+			has_doctrine = muhammad_succession_shia_doctrine
+			faiths_are_shia_zandaqa_sub_group = yes
+		}
+	}
+	$FAITH_2$ = {
+		OR = {
+			has_doctrine = muhammad_succession_shia_doctrine
+			has_doctrine = muhammad_succession_muhakkima_doctrine
+			faiths_are_shia_zandaqa_sub_group = yes
+			this = faith:valentinianism
+			this = faith:sabianism
+		}
+	}
+}
+
+faiths_are_in_muhakkima_islam_group = {
+	$FAITH_1$ = {
+		has_doctrine = muhammad_succession_muhakkima_doctrine
+	}
+	$FAITH_2$ = {
+		OR = {
+			has_doctrine = muhammad_succession_muhakkima_doctrine
+			this = faith:manichean
+			this = faith:valentinianism
+		}
+	}
+}
+
+faiths_are_eastern_zoroastrian = { #FP3 update - so that Armenian faith (Arewordik) don't appear as a heresy in Sogdia
+	OR = {
+		$FAITH_1$ = faith:mazdayasna
+		$FAITH_1$ = faith:khurmazta
+		$FAITH_1$ = faith:gayomarthianism
+		$FAITH_2$ = faith:zurvanism
+		$FAITH_2$ = faith:mazdakism
+		$FAITH_2$ = faith:khurramism
+	}
+	OR = {
+		$FAITH_1$ = faith:mazdayasna
+		$FAITH_1$ = faith:khurmazta
+		$FAITH_1$ = faith:gayomarthianism
+		$FAITH_2$ = faith:zurvanism
+		$FAITH_2$ = faith:mazdakism
+		$FAITH_2$ = faith:khurramism
+	}
+}
+
+faiths_are_western_zoroastrian = { #FP3 update - so that Sogdian faith (Khurmazta) don't appear as a heresy in Armenia 
+	OR = {
+		$FAITH_1$ = faith:mazdayasna
+		$FAITH_1$ = faith:gayomarthianism
+		$FAITH_2$ = faith:zurvanism
+		$FAITH_2$ = faith:mazdakism
+		$FAITH_2$ = faith:khurramism
+		$FAITH_2$ = faith:urartuism
+	}
+	OR = {
+		$FAITH_1$ = faith:mazdayasna
+		$FAITH_1$ = faith:gayomarthianism
+		$FAITH_2$ = faith:zurvanism
+		$FAITH_2$ = faith:mazdakism
+		$FAITH_2$ = faith:khurramism
+		$FAITH_2$ = faith:urartuism
+	}
+}
+
+refusing_conversion_is_crime_trigger = {
+	faith = {
+		OR = {
+			religion_tag = christianity_religion
+			religion_tag = islam_religion
+			religion_tag = judaism_religion
+			religion_tag = zoroastrianism_religion
+		}
+		NOT = {
+			faith_hostility_level = {
+				target = $CHARACTER$.faith
+				value <= faith_astray_level
+			}
+		}
+	}
+}
+
+is_hostile_enough_for_holy_war_trigger = {
+	faith_hostility_level = {
+		target = $FAITH$
+		value >= religious_cb_enabled_hostility_level
+	}
+}
+
+barony_is_valid_for_holy_order_lease_trigger = {
+	title_province = {
+		OR = {
+			has_holding_type = castle_holding
+			has_holding_type = city_holding
+		}
+	}
+	trigger_if = {
+		limit = {
+			holder.primary_title.tier != tier_barony
+		}
+		can_be_leased_out = yes
+	}
+	trigger_if = {
+		limit = {
+			NOT = { holder = $CHARACTER$ }
+		}
+		holder.primary_title.tier = tier_barony	
+	}
+	NOT = {
+		is_leased_out = yes
+	}
+}
+
+barony_is_valid_for_holy_order_lease_cancellation_trigger = {
+	is_under_holy_order_lease = yes
+	has_revokable_lease = yes
+	lessee = {
+		NOT = {
+			has_strong_hook = prev.holder
+		}
+	}
+}
+
+religion_has_angels_trigger = {
+	OR = {
+		religion = religion:christianity_religion
+		religion = religion:islam_religion
+		religion = religion:zoroastrianism_religion
+		religion = religion:dualism_religion
+		religion = religion:judaism_religion
+		religion = religion:yazidi_religion
+	}
+}
+
+religion_has_circumcision_trigger = {
+	OR = {
+		religion = religion:islam_religion
+		religion = religion:judaism_religion
+	}
+}
+
+is_heretic_trigger = {
+	$WHO$.faith.religion = $TARGET$.faith.religion
+	$WHO$.faith = {
+		faith_hostility_level = {
+			target = $TARGET$.faith
+			value >= religious_cb_enabled_hostility_level
+		}
+	}
+}
+
+is_heathen_trigger = {
+	NOT = { $WHO$.faith.religion = $TARGET$.faith.religion }
+	$TARGET$.faith = {
+		has_doctrine = pagan_hostility_doctrine
+	}
+	$WHO$.faith = {
+		faith_hostility_level = {
+			target = $TARGET$.faith
+			value >= religious_cb_enabled_hostility_level
+		}
+	}
+}
+
+is_infidel_trigger = {
+	NOT = { $WHO$.faith.religion = $TARGET$.faith.religion }
+	$TARGET$.faith = {
+		NOT = { has_doctrine = pagan_hostility_doctrine }
+	}
+	$WHO$.faith = {
+		faith_hostility_level = {
+			target = $TARGET$.faith
+			value >= religious_cb_enabled_hostility_level
+		}
+	}
+}
+
+valid_demand_conversion_conditions_trigger = {
+	scope:recipient = { is_busy_in_events_localised = yes }
+	scope:recipient = { NOT = { has_strong_hook = scope:actor } }
+	scope:recipient = { NOT = { has_trait = devoted } }
+	scope:recipient = { NOT = { has_trait = order_member } }
+	scope:recipient = {
+		NOT = { is_imprisoned_by = scope:actor }
+	}
+	scope:recipient = {
+		NOT = { is_at_war_with = scope:actor }
+	}
+
+	custom_description = {
+		text = "is_head_of_religion"
+		subject = scope:recipient
+		NOT = { scope:recipient.faith.religious_head = scope:recipient }
+	}
+
+	custom_description = {
+		text = "is_protected_via_contract"
+		subject = scope:recipient
+		NAND = { # Vassal Contract forbids meddling by liege
+			exists = scope:recipient.liege
+			scope:recipient.liege = scope:actor
+			scope:recipient = {
+				is_ruler = yes
+				vassal_contract_has_flag = religiously_protected
+			}
+		}
+	}
+	
+	trigger_if = {
+		limit = {
+			scope:recipient = {	
+				AND = {
+					has_variable = cannot_be_converted_by_value
+					var:cannot_be_converted_by_value = scope:actor	
+				}
+			}
+		}
+		custom_tooltip = {
+			text = promised_to_not_convert_character
+			scope:recipient = {	
+				NOR = {
+					has_variable = cannot_be_converted_by_value
+					var:cannot_be_converted_by_value = scope:actor
+				}
+			}
+		}
+	}
+
+	custom_tooltip = {
+		text = cannot_take_overt_hostile_actions_against_diarch.tt
+		NOT = { scope:recipient ?= scope:actor.diarch }
+	}
+}
+
+highgod_is_passive_trigger = {
+	OR = {
+		religion_tag = buddhism_religion
+		religion_tag = jainism_religion
+		religion_tag = taoism_religion
+		religion_tag = west_african_roog_religion
+		religion_tag = zunism_religion
+	}
+}
+
+highgod_is_active_trigger = {
+	highgod_is_passive_trigger = no
+}
+
+
+fertilitygod_is_active_trigger = {
+	highgod_is_active_trigger = yes
+}
+
+
+###REINCARNATION###
+can_become_reincarnation_trigger = {
+	save_temporary_scope_as = reincarnated_child
+	faith = {
+		has_doctrine = tenet_reincarnation
+	}
+	any_parent = {
+		is_landed = yes
+		faith = scope:reincarnated_child.faith
+	}
+}
+
+can_reincarnate_trigger = {
+	is_alive = no
+	OR = {
+		has_trait = temperate
+		has_trait = greedy
+		has_trait = generous
+		has_trait = diligent
+		has_trait = calm
+		has_trait = arrogant
+		has_trait = humble
+		has_trait = deceitful
+		has_trait = honest
+		has_trait = brave
+		has_trait = gregarious
+		has_trait = ambitious
+		has_trait = just
+		has_trait = zealous
+		has_trait = compassionate
+		has_trait = stubborn
+		has_trait = forgiving
+		has_trait = lunatic
+		has_trait = dull
+		has_trait = intellect_bad
+		has_trait = shrewd
+		has_trait = intellect_good
+		has_trait = strong
+		has_trait = physique_good
+	}
+}
+
+is_reincarnation_trigger = {
+	can_become_reincarnation_trigger = yes
+	OR = {
+		AND = {
+			has_variable = reincarnation_of
+
+		}
+
+	}
+}
+
+# Used in faith scope, COUNT is number of faiths to at least have and CHARACTER is who must own them
+num_realm_holy_sites_faithful_holders = {
+	custom_description = {
+		text = number_realm_holy_sites_held_by_faithful
+		subject = $CHARACTER$
+		object = this
+		value = $COUNT$
+		any_holy_site = {
+			count >= $COUNT$
+			county = {
+				is_holy_site_controlled_by = $CHARACTER$
+				holder.faith = $CHARACTER$.faith
+			}
+		}
+	}
+}
+
+### Head of Faith
+can_create_temporal_head_of_faith_title_trigger = {
+	num_realm_holy_sites_faithful_holders = {
+		COUNT = holy_sites_to_create_temporal_head_of_faith
+		CHARACTER = ROOT
+	}
+	root = { piety_level >= high_piety_level }
+	trigger_if = {
+		limit = {
+			root = { is_independent_ruler = no }
+		}
+		custom_description = {
+			text = cannot_create_hof_title_at_or_above_liege_tier
+			root.liege.primary_title.tier > tier_duchy
+		}
+	}
+}
+
+can_create_spiritual_head_of_faith_title_trigger = {
+	num_realm_holy_sites_faithful_holders = {
+		COUNT = holy_sites_to_create_spiritual_head_of_faith
+		CHARACTER = ROOT
+	}
+	root = { piety_level >= medium_piety_level }
+	trigger_if = {
+		limit = { has_doctrine = special_doctrine_not_allowed_to_hof }
+		NOT = { has_doctrine = special_doctrine_not_allowed_to_hof }
+	}
+}
+
+# this = Person trying to create the title
+can_afford_create_head_of_faith_title_cost_trigger = {
+	trigger_if = {
+		limit = {
+			faith = {
+				has_doctrine_parameter = temporal_head_of_faith
+				OR = {
+					has_doctrine = muhammad_succession_sunni_doctrine
+					has_doctrine = muhammad_succession_shia_doctrine
+				}
+			}		
+		}
+		trigger_if = {
+			limit = { NOT = { has_trait = sayyid } }
+			piety >= massive_piety_value
+		}
+	}
+	trigger_else_if = {
+		limit = {
+			faith = {
+				has_doctrine_parameter = temporal_head_of_faith
+			}
+		}
+		piety >= major_piety_value
+	}
+	trigger_else = {
+		limit = {
+			faith = {
+				has_doctrine_parameter = spiritual_head_of_faith
+			}
+		}
+		gold >= medium_gold_max_value
+	}
+}
+
+# FAITH = The faith we are trying to make the head of faith title for
+# this = Person trying to create the title
+can_create_head_of_faith_title_trigger = {
+	$FAITH$ = {
+		trigger_if = {
+			limit = {
+				has_doctrine_parameter = spiritual_head_of_faith
+			}
+			can_create_spiritual_head_of_faith_title_trigger = yes
+		}
+		trigger_else_if = {
+			limit = {
+				has_doctrine_parameter = temporal_head_of_faith
+			}
+			can_create_temporal_head_of_faith_title_trigger = yes
+		}
+		trigger_else = {
+			# We shouldn't hit this point, but if we do use the following as error messages.
+			has_doctrine_parameter = spiritual_head_of_faith
+			has_doctrine_parameter = temporal_head_of_faith
+		}
+	}
+	can_afford_create_head_of_faith_title_cost_trigger = yes
+}
+
+can_perform_the_hajj_trigger = {
+	faith.religion = religion:islam_religion
+	faith = { has_doctrine_parameter = can_go_on_pilgrimage }
+}
+
+shared_faith_or_hof_trigger = {
+	OR = {
+		$ACTOR$.faith = $RECIPIENT$.faith
+		AND = {
+			exists = $ACTOR$.faith.religious_head
+			exists = $RECIPIENT$.faith.religious_head
+			$ACTOR$.faith.religious_head = $RECIPIENT$.faith.religious_head
+		}
+	}
+}
+
+
+###RELIGIOUS INTERACTIONS###
+#Triggers that applies to both Monastery or Holy Order requirements
+can_take_religious_vows_trigger = {
+	can_take_religious_vows_disregard_marriage_trigger = yes
+	
+	#Do they have the "wrong" marriage type?
+	NOR = {
+		custom_description = {
+			text = is_married_matrilineally
+			subject = scope:recipient
+			any_spouse = {
+				is_female = yes
+				matrilinear_marriage = yes
+			}
+		}
+		custom_description = {
+			text = is_married_patrilineally
+			subject = scope:recipient
+			any_spouse = {
+				is_male = yes
+				patrilinear_marriage = yes
+			}
+		}
+		custom_description = {
+			text = matrilinear_betrothal
+			subject = scope:recipient
+			exists = betrothed
+			betrothed = {
+				is_female = yes
+				matrilinear_betrothal = yes
+			}
+		}
+		custom_description = {
+			text = patrilinear_betrothal
+			subject = scope:recipient
+			exists = betrothed
+			betrothed = {
+				is_male = yes
+				patrilinear_betrothal = yes
+			}
+		}
+	}
+	bp2_valid_for_standard_interactions_trigger = yes
+}
+
+can_take_religious_vows_disregard_marriage_trigger = {
+	is_available_ai = yes
+	faith = scope:actor.faith
+	is_ruler = no
+	NOT = { has_trait = excommunicated }
+	NOT = { has_character_flag = holy_order_member_requested_return_home }
+}
+
+does_religion_exist_in_world_region_trigger = { # The most efficient way I could think of to esentially do diplomatic range triggers on religions
+	trigger_if = {
+		limit = { location = { geographical_region = world_europe } } # Even though europe has many sub regions, it's overall size is small so no need to sub-divide!
+		any_county_in_region = {
+			region = world_europe
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = {
+		limit = { location = { geographical_region = world_asia_minor } } # Maybe this should be grouped with both the one above and the one below...
+		any_county_in_region = {
+			region = world_asia_minor
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = {
+		limit = { location = { geographical_region = world_middle_east } }
+		any_county_in_region = {
+			region = world_middle_east
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = {
+		limit = {
+			location = { geographical_region = world_india } }
+		any_county_in_region = {
+			region = world_india
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = {
+		limit = { location = { geographical_region = world_africa } }
+		any_county_in_region = {
+			region = world_africa
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = {
+		limit = { location = { geographical_region = world_steppe } }
+		any_county_in_region = {
+			region = world_steppe
+			faith.religion = $RELIGION$
+		}
+	}
+	trigger_else_if = { # We group two smaller world regions into one
+		limit = {
+			location = {
+				OR = {
+					geographical_region = world_tibet
+					geographical_region = world_burma
+				}
+			}
+		}
+		OR = {
+			any_county_in_region = {
+				region = world_tibet
+				faith.religion = $RELIGION$
+			}
+			any_county_in_region = {
+				region = world_burma
+				faith.religion = $RELIGION$
+			}
+		}
+	}
+	trigger_else = { always = no } # This should always go at the end of this scripted trigger
+}
+
+### HOLY ORDERS ###
+holy_order_1000_holy_order_trigger = {
+	title = {
+		NOR = {
+			has_variable = received_new_land
+			has_variable = discarded_for_being_too_big
+		}
+	}
+}
+
+holy_order_1000_target_barony_trigger = {
+	tier = tier_barony
+	barony_is_valid_for_holy_order_lease_trigger = { CHARACTER = $CHARACTER$ }
+	#Don't grab something that's held by a vassal player of the one receiving the event.
+	trigger_if = {
+		limit = {
+			NOT = { holder = $CHARACTER$ }
+		}
+		holder = { is_ai = yes }
+	}
+}
+
+holy_order_1000_request_target_trigger = {
+	highest_held_title_tier >= tier_duchy
+	is_landed = yes
+	faith = root
+	is_available = yes
+	NOR = {
+		has_character_flag = holy_order_recently_requested_land
+		has_character_flag = holy_order_recently_received_land
+	}
+	save_temporary_scope_as = ruler
+	any_sub_realm_barony = {
+		holy_order_1000_target_barony_trigger = { CHARACTER = scope:ruler }
+	}
+}
+
+faith_dominant_gender_male_or_equal = {
+	faith = {
+		OR = {
+			has_doctrine_parameter = male_dominated_law
+			has_doctrine_parameter = gender_equal_law
+		}
+	}
+}
+
+faith_dominant_gender_female_or_equal = {
+	faith = {
+		OR = {
+			has_doctrine_parameter = female_dominated_law
+			has_doctrine_parameter = gender_equal_law
+		}
+	}
+}
+
+is_theological_character_trigger = {
+	OR = {
+		has_trait = theologian
+		has_trait = devoted
+		has_trait = order_member
+		AND = {
+			is_landed = yes
+			government_has_flag = government_is_theocracy
+		}
+
+	}	
+}
+
+would_be_sinful_adulterer_trigger = {
+	is_married = yes
+	trigger_if = {
+		limit = { is_male = yes }
+		NOT = {
+			faith = { has_doctrine = doctrine_adultery_men_accepted }
+		}
+	}
+	trigger_else = {
+		NOT = {
+			faith = { has_doctrine = doctrine_adultery_women_accepted }
+		}
+	}
+}
+
+has_tolerant_faith_or_culture_trigger = {
+	OR = {
+		faith = { has_doctrine = doctrine_pluralism_pluralistic }
+		culture = { has_cultural_parameter = less_likely_to_force_conversion }
+	}
+}
+
+is_mainstream_jewish_faith = {
+	religion = religion:judaism_religion
+	NOT = {
+		this = faith:samaritan
+		this = faith:haymanot
+		this = faith:malabarism
+		this = faith:kabarism
+	}
+}
+
+is_unprotected_hostile_faith = { # Checks if the faith is at least hostile but not protected by a contract, used in a county scope
+	faith = {
+		faith_hostility_level = {
+			target = prev.holder.top_liege.faith
+			value >= 2
+		}
+	}
+	holder = {
+		NOT = { vassal_contract_has_flag = religiously_protected }
+	}
+	trigger_if = { # Does anyone in the hierarchy have religious protection?
+		limit = {
+			holder = {
+				any_liege_or_above = {
+					faith = prev.faith
+				}
+			}
+		}
+		holder = {
+			any_liege_or_above = {
+				NOT = { vassal_contract_has_flag = religiously_protected }
+			}
+		}
+	}
+}
+
+### SYNCRETIC TRIGGERS ###
+
+islam_or_syncretic_with_islam_trigger = {
+	$CHARACTER$ = {
+		faith = {
+			OR = {
+				religion = religion:islam_religion
+				has_doctrine = tenet_islamic_syncretism
+			}
+		}
+	}
+}
+
+judaism_or_syncretic_with_judaism_trigger = {
+	$CHARACTER$ = {
+		faith = {
+			OR = {
+				religion = religion:judaism_religion
+				has_doctrine = tenet_jewish_syncretism
+			}
+		}
+	}
+}
+
+christianity_or_syncretic_with_christianity_trigger = {
+	$CHARACTER$ = {
+		faith = {
+			OR = {
+				religion = religion:christianity_religion
+				has_doctrine = tenet_christian_syncretism
+			}
+		}
+	}
+}
+
+unreformed_or_syncretic_with_unreformed_trigger = {
+	$CHARACTER$ = {
+		faith = {
+			OR = {
+				religion = religion:unreformed_religion
+				has_doctrine = tenet_unreformed_syncretism
+			}
+		}
+	}
+}
+
+zoroastrian_or_syncretic_with_eastern_trigger = {
+	$CHARACTER$ = {
+		faith = {
+			OR = {
+				religion = religion:zoroastrianism_religion
+				has_doctrine = tenet_eastern_syncretism
+			}
+		}
+	}
+}
+
+#Used on faiths
+is_dharmic_faith_trigger = {
+	OR = {
+		religion = religion:hinduism_religion
+		religion = religion:buddhism_religion
+		religion = religion:jainism_religion
+	}
+}
+
+#Used on provinces
+has_holy_building = {
+	OR = {
+		has_building_or_higher = holy_site_cathedral_01
+		has_building_or_higher = holy_site_mosque_01
+		has_building_or_higher = holy_site_pagan_grand_temple_01
+		has_building_or_higher = holy_site_indian_grand_temple_01
+		has_building_or_higher = holy_site_other_grand_temple_01
+		has_building_or_higher = holy_site_cologne_cathedral_01
+		has_building_or_higher = holy_site_canterbury_cathedral_01
+		has_building_or_higher = temple_of_uppsala_01
+		has_building_or_higher = lund_cathedral_01
+		has_building_or_higher = notre_dame_01
+		has_building_or_higher = holy_site_imam_ali_mosque_01
+		has_building_or_higher = holy_site_great_mosque_of_mecca_01
+		has_building_or_higher = holy_site_great_mosque_of_cordoba_01
+		has_building_or_higher = holy_site_great_mosque_of_djenne_01
+		has_building_or_higher = holy_site_great_mosque_of_samarra_01
+		has_building_or_higher = holy_site_prophetic_mosque_01
+		has_building_or_higher = dome_of_the_rock_01
+		has_building_or_higher = temple_in_jerusalem_01
+	}
+}
+
+invalid_for_heresy_events = {
+	OR = {
+		this = faith:conversos
+		this = faith:insular_celtic
+		this = faith:bosnian_church
+		this = faith:mozarabic_church
+		this = faith:adamites
+		this = faith:kabarism
+	}
+}
+

--- a/common/scripted_triggers/mandatory_consaquinity_triggers.txt
+++ b/common/scripted_triggers/mandatory_consaquinity_triggers.txt
@@ -1,0 +1,93 @@
+﻿
+
+
+#Needs CHARACTER and FAITH
+relation_with_character_is_not_incestuous_in_faith_trigger = {
+	AND = {
+		$FAITH$ = { has_doctrine = doctrine_consanguinity_mandatory }
+		NOT = { 
+			is_close_or_extended_family_of = $CHARACTER$ #[parents, children, siblings, grandparents, grandchildren, cousins, uncles, aunts, nephews, nieces]
+		}
+	}
+}
+
+#relation_with_character_is_not_incestuous_in_my_or_lieges_faith_trigger = {
+#	OR = {
+#		AND = {
+#			faith = { #My faith doesn't approve
+#				save_temporary_scope_as = check_faith
+#			}
+#			relation_with_character_is_not_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+#		}
+#		AND = { #Liege's faith doesn't approve
+#			exists = liege
+#			liege = {
+#				faith = {
+#					save_temporary_scope_as = check_faith
+#				}
+#			}
+#			relation_with_character_is_not_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:check_faith }
+#		}
+#	}
+#}
+
+#Note: only checks from the viewpoint of current scope. Needs CHARACTER
+#relation_with_character_is_not_incestuous_in_my_faith_trigger = {
+#	faith = { save_temporary_scope_as = my_faith }
+#	relation_with_character_is_not_incestuous_in_faith_trigger = { CHARACTER = $CHARACTER$ FAITH = scope:my_faith }
+#}
+
+#is_notincestuous_trigger = {
+#	OR = {
+#		has_trait = notincestuous
+#		any_secret = {
+#			secret_type = secret_notincest
+#		}
+#	}
+#}
+
+# SECRET not INCEST
+#secret_notincest_is_valid_trigger = {
+#	$OWNER$ = {
+#		NOT = {
+#			has_trait = notincestuous
+#		}
+#	}
+#}
+
+#secret_notincest_is_shunned_trigger = {
+#	$OWNER$ = { always = no }
+#}
+
+#secret_notincest_is_criminal_trigger = {
+#	$OWNER$ = {
+#		OR = {
+#			faith = { has_doctrine_parameter = consanguinity_mandatory_incest }
+#			any_liege_or_above = { faith = { has_doctrine_parameter = consanguinity_mandatory_incest } }
+#		}
+#	}
+#}
+
+#give_random_likely_secret_notincestous_lover_trigger = {
+#	is_adult = yes
+#	is_ai = yes
+#	NOT = { any_relation = { type = lover this = scope:lover_1 } }
+#	NOT = { is_spouse_of = scope:lover_1 }
+#	NOT = { relation_with_character_is_not_incestuous_in_my_or_lieges_faith_trigger = { CHARACTER = scope:lover_1 } }
+#	OR = {
+#		save_temporary_scope_as = lover_2
+#		possible_mutual_interest_trigger = { CHARACTER_1 = scope:lover_1 CHARACTER_2 = scope:lover_2 }
+#		AND = {
+#			matching_gender_and_sexuality_trigger = { CHARACTER_1 = scope:lover_1 CHARACTER_2 = scope:lover_2 }
+#			opinion = {
+#				target = scope:lover_1
+#				value >= 40
+#			}
+#			reverse_opinion = {
+#				target = scope:lover_1
+#				value >= 40
+#			}
+#		}
+#	}
+#	
+#}

--- a/localization/english/consanguinity_l_english.yml
+++ b/localization/english/consanguinity_l_english.yml
@@ -1,0 +1,5 @@
+l_english:
+ doctrine_consanguinity_mandatory_name:0 "Mandatory Consanguinity"
+ doctrine_consanguinity_mandatory_desc:0 "True love can only exist between family members. Having sexual relations with someone who is not related is a sin against [ROOT.Faith.HighGodName]."
+ doctrine_parameter_consanguinity_mandatory_marriage:0 "Marriage only between family members is allowed"
+ doctrine_parameter_consanguinity_mandatory_incest:0 "Sexual relations between non family members will give the not-incest [secret|E]"


### PR DESCRIPTION
Adding 'Mandatory Consanguinity' doctrine under the 'Consanguinity' section of a faith. Adds the relevant localization items and ensures 'Divine Marriage' tenet can be picked with both 'Unrestricted Marriage' and 'Mandatory Consanguinity' doctrines.