### PR TITLE
Pureblood tweaks

### DIFF
--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -356,11 +356,17 @@ pure_blooded_inheritance_effect = {
 		limit = {
 			AND = {
 				scope:real_father = {
-					has_trait = purer_blooded
+					OR = {
+						has_trait = purer_blooded
+						has_trait = purest_blooded
+					}
 					is_twin_of = scope:mother
 				}
 				scope:mother = {
-					has_trait = purer_blooded
+					OR = {
+						has_trait = purer_blooded
+						has_trait = purest_blooded
+					}
 					is_twin_of = scope:real_father
 				}
 			}
@@ -376,6 +382,70 @@ pure_blooded_inheritance_effect = {
 			}
 		}
 	}
+
+	else_if = { # both parents purer_blooded, not related
+		limit = {
+			AND = {
+				scope:real_father = {
+					has_trait = purer_blooded
+				}
+				scope:mother = {
+					has_trait = purer_blooded
+				}
+			}
+		}
+		remove_pure_blooded = yes
+		random_list = {
+			70 = {
+				add_trait = pure_blooded
+			}
+			30 = {
+				add_trait = purer_blooded
+			}
+		}
+	}
+
+	else_if = { # both parents purest_blooded & related
+		limit = {
+			AND = {
+				scope:real_father = {
+					has_trait = purest_blooded
+					is_close_or_extended_family_of = scope:mother
+				}
+				scope:mother = {
+					has_trait = purest_blooded
+					is_close_or_extended_family_of = scope:mother
+				}
+			}
+		}
+		remove_pure_blooded = yes
+		random_list = {
+			90 = {
+				add_trait = purer_blooded
+			}
+			10 = {
+				add_trait = purest_blooded
+			}
+		}
+	}
+
+	else_if = { # both parents purest_blooded, not related
+		limit = {
+			AND = {
+				scope:real_father = {
+					has_trait = purest_blooded
+				}
+				scope:mother = {
+					has_trait = purest_blooded
+				}
+			}
+		}
+		remove_pure_blooded = yes
+		add_trait = purer_blooded
+	}
+
+
+
 
 	else_if = { # greater than pure_blooded
 		limit = {
@@ -400,4 +470,21 @@ pure_blooded_inheritance_effect = {
 			}
 		}
 	}
+
+
+	else_if = { # greater than pure_blooded, not related
+		limit = {
+			blood_score > 3
+		}
+		remove_pure_blooded = yes
+		random_list = {
+			70 = {
+				add_trait = pure_blooded
+			}
+			30 = {
+				add_trait = purer_blooded
+			}
+		}
+	}
+
 }

--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -466,23 +466,26 @@ pure_blooded_inheritance_effect = {
 
 else_if = { # One last edge case to make purer/purest at least equivalent to pure
 		limit = {
-			OR = {
-				scope:mother = {
-					OR = {
-						has_trait = purest_blooded
-						has_trait = purer_blooded
+			AND = {
+				NOT = {
+            		has_trait = pure_blooded
+        		}
+        		OR = {
+					scope:mother = {
+						OR = {
+							has_trait = purest_blooded
+							has_trait = purer_blooded
+						}
 					}
-				}
-				scope:real_father = {
-					OR = {
-						has_trait = purest_blooded
-						has_trait = purer_blooded
+					scope:real_father = {
+						OR = {
+							has_trait = purest_blooded
+							has_trait = purer_blooded
+						}
 					}
 				}
 			}
-
 		}
-		remove_pure_blooded = yes
 		random_list = {
 			45 = {
 				add_trait = pure_blooded

--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -383,28 +383,6 @@ pure_blooded_inheritance_effect = {
 		}
 	}
 
-	else_if = { # both parents purer_blooded, not related
-		limit = {
-			AND = {
-				scope:real_father = {
-					has_trait = purer_blooded
-				}
-				scope:mother = {
-					has_trait = purer_blooded
-				}
-			}
-		}
-		remove_pure_blooded = yes
-		random_list = {
-			70 = {
-				add_trait = pure_blooded
-			}
-			30 = {
-				add_trait = purer_blooded
-			}
-		}
-	}
-
 	else_if = { # both parents purest_blooded & related
 		limit = {
 			AND = {
@@ -445,8 +423,6 @@ pure_blooded_inheritance_effect = {
 	}
 
 
-
-
 	else_if = { # greater than pure_blooded
 		limit = {
 			AND = {
@@ -472,7 +448,7 @@ pure_blooded_inheritance_effect = {
 	}
 
 
-	else_if = { # greater than pure_blooded, not related
+	else_if = { # At least one parent purer+, not related
 		limit = {
 			blood_score > 3
 		}

--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -463,4 +463,20 @@ pure_blooded_inheritance_effect = {
 		}
 	}
 
+
+	else_if = { # One last edge case to make purer/purest at least equivalent to pure
+		limit = {
+			blood_score > 1
+		}
+		remove_pure_blooded = yes
+		random_list = {
+			45 = {
+				add_trait = pure_blooded
+			}
+			55 = {
+				#Do Nothing
+			}
+		}
+	}
+
 }

--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -468,9 +468,9 @@ else_if = { # One last edge case to make purer/purest at least equivalent to pur
 		limit = {
 			AND = {
 				NOT = {
-            		has_trait = pure_blooded
-        		}
-        		OR = {
+					has_trait = pure_blooded
+				}
+				OR = {
 					scope:mother = {
 						OR = {
 							has_trait = purest_blooded

--- a/common/scripted_effects/elf_genetic_trait_effects.txt
+++ b/common/scripted_effects/elf_genetic_trait_effects.txt
@@ -464,9 +464,23 @@ pure_blooded_inheritance_effect = {
 	}
 
 
-	else_if = { # One last edge case to make purer/purest at least equivalent to pure
+else_if = { # One last edge case to make purer/purest at least equivalent to pure
 		limit = {
-			blood_score > 1
+			OR = {
+				scope:mother = {
+					OR = {
+						has_trait = purest_blooded
+						has_trait = purer_blooded
+					}
+				}
+				scope:real_father = {
+					OR = {
+						has_trait = purest_blooded
+						has_trait = purer_blooded
+					}
+				}
+			}
+
 		}
 		remove_pure_blooded = yes
 		random_list = {
@@ -474,7 +488,7 @@ pure_blooded_inheritance_effect = {
 				add_trait = pure_blooded
 			}
 			55 = {
-				#Do Nothing
+				Do Nothing
 			}
 		}
 	}


### PR DESCRIPTION
Modifications to Purer[2] & Purest[3] blooded inheritance to make them a bit more consistent with pure-blooded[1],

- Purest[3] blooded is still only passed on by twins (either purer[2] or purest[3] blooded), with one exception. If both parents are Purest[3] already AND they are `is_close_or_extended_family_of` each other, then there's a 1/10 chance the child will also be purest[3], otherwise the child will inherit purer[2].  
- Most of the other changes either guarantee or improve the chances of at least some level of the pure blood trait getting inherited, the goal was to make the higher level traits at least equivalent to pure[1] whenever special conditions aren't met. 