### PR TITLE
Tweaks to daughter's return from weaver school

### DIFF
--- a/common/on_action/elven_quarterly_pulse.txt
+++ b/common/on_action/elven_quarterly_pulse.txt
@@ -127,8 +127,8 @@ elf_daughters_back_from_school = {
 		}
 		any_child = {
 			is_female = yes
-			age > 15
-			age < 20
+			age > 12
+			age < 16
 			has_character_flag = recruited_by_aelurans
 		}
 	}

--- a/events/aeluran/aeluran_repeating_events.txt
+++ b/events/aeluran/aeluran_repeating_events.txt
@@ -110,16 +110,13 @@ aeluran_repeating.002 = { # Daughters returned from Aelurans
 			add_trait = magi
 			add_trait = aeluran_sister
 
-			set_location = root.location
-			# stick_to_location
-			
+			set_location_to_default = yes
 		}
 	}
 
 	option = {
 		name = aeluran_repeating.002.ok
 		add_courtier = scope:daughter
-		set_location_to_default = yes
 	}
 
 }

--- a/events/aeluran/aeluran_repeating_events.txt
+++ b/events/aeluran/aeluran_repeating_events.txt
@@ -99,8 +99,8 @@ aeluran_repeating.002 = { # Daughters returned from Aelurans
 		random_child = {
 			limit = {
 				is_female = yes
-				age > 15
-				age < 20
+				age > 12
+				age < 16
 				has_character_flag = recruited_by_aelurans
 			}
 			save_scope_as = daughter
@@ -119,6 +119,7 @@ aeluran_repeating.002 = { # Daughters returned from Aelurans
 	option = {
 		name = aeluran_repeating.002.ok
 		add_courtier = scope:daughter
+		set_location_to_default = yes
 	}
 
 }


### PR DESCRIPTION
**Daughters return a bit earlier at age 13/14**
  - Avoids any court location weirdness caused by fulfilling a betrothal before returning "officially", etc. 
  - Allows them to benefit from location-based education (town maven, etc).  

**Daughters will now return to their default court location.** 
- I've noticed that if my current liege is commanding abroad, his daughter returns there instead of the actual court location. This change fixes that. 
- There might be other edge cases this change resolves.