### PR TITLE
Fix multi-birth count stomped to 1 by vanilla pregnancy events

### DIFF
--- a/events/elf_pregnancy_events.txt
+++ b/events/elf_pregnancy_events.txt
@@ -50,14 +50,45 @@ elf_pregnancy_events.0001 = {
 	}
 }
 
-# Multi-birth adjustment
+# Multi-birth adjustment (trampoline).
+# Fires from on_pregnancy_mother. Defers the actual roll to .0003 with a
+# one-day delay so set_num_pregnancy_children is written *after* every
+# vanilla pregnancy event in the same on_action has finished its
+# immediate block.
+#
+# Why the delay is necessary: vanilla pregnancy.2001, pregnancy.2002 and
+# pregnancy.2050 each call `set_num_pregnancy_children = 1` in their own
+# hidden_effect. They are queued from the same on_pregnancy_mother
+# on_action as this event, so the resolution order between this event's
+# immediate and theirs is not guaranteed. When a vanilla one resolves
+# afterward, the count is stomped back to 1 while the having_X flag we
+# set on the mother stays - producing a "Six-pack Surprise" title
+# (or similar) on a single-child birth. A one-day delayed trigger_event
+# guarantees the body in .0003 runs strictly after all vanilla
+# on_pregnancy_mother events.
 elf_pregnancy_events.0002 = {
     hidden = yes
-	
+
     trigger = {
 		culture = {
 			has_cultural_parameter = multi_birthing
 		}
+	}
+
+	immediate = {
+		trigger_event = {
+			id = elf_pregnancy_events.0003
+			days = 1
+		}
+	}
+}
+
+# Multi-birth adjustment (deferred body, see .0002 for rationale).
+elf_pregnancy_events.0003 = {
+    hidden = yes
+
+	trigger = {
+		scope:mother = { is_pregnant = yes }
 	}
 
 	immediate = {
@@ -114,40 +145,32 @@ elf_pregnancy_events.0002 = {
 		}
 
 		## Assign number of children
-		random_list  = {
-			21 = {
-				set_num_pregnancy_children = 1
-			}
-			40 = {
-				set_num_pregnancy_children = 2
-			}
-			20 = {
-				set_num_pregnancy_children = 3
-				scope:mother = {
+		scope:mother = {
+			random_list  = {
+				21 = {
+					set_num_pregnancy_children = 1
+				}
+				40 = {
+					set_num_pregnancy_children = 2
+				}
+				20 = {
+					set_num_pregnancy_children = 3
 					add_character_flag = having_triplets
 				}
-			}
-			10 = {
-				set_num_pregnancy_children = 4
-				scope:mother = {
+				10 = {
+					set_num_pregnancy_children = 4
 					add_character_flag = having_quadruplets
 				}
-			}
-			5 = {
-				set_num_pregnancy_children = 5
-				scope:mother = {
+				5 = {
+					set_num_pregnancy_children = 5
 					add_character_flag = having_quintuplets
 				}
-			}
-			3 = {
-				set_num_pregnancy_children = 6
-				scope:mother = {
+				3 = {
+					set_num_pregnancy_children = 6
 					add_character_flag = having_sextuplets
 				}
-			}
-			1 = {
-				set_num_pregnancy_children = 7
-				scope:mother = {
+				1 = {
+					set_num_pregnancy_children = 7
 					add_character_flag = having_septuplets
 				}
 			}


### PR DESCRIPTION
## Summary

- Split `elf_pregnancy_events.0002` into a trampoline that defers to a new `.0003` with a 1-day delay, and move the multi-birth roll into `.0003`.
- Ensures `set_num_pregnancy_children` is the last value written for the pregnancy, so the count actually matches the multi-birth flag the mother gets tagged with.

## Why

`elf_pregnancy_events.0002` is queued from `on_pregnancy_mother`. Vanilla `pregnancy.2001`, `pregnancy.2002` and `pregnancy.2050` are queued from the same on_action and each call `set_num_pregnancy_children = 1` inside their own `hidden_effect`. The resolution order between this event's immediate and theirs is not guaranteed.

When a vanilla one resolves afterward (which happens for bastard and same-sex pregnancies in particular), the count is stomped back to `1` while the `having_triplets` / `having_quadruplets` / ... / `having_septuplets` flag this event set on the mother stays put. The result is the birth event picking the matching title (e.g. "Six-pack Surprise") on a single-child birth — the symptom users have reported.

Delaying the roll by one day moves `.0003`'s `set_num_pregnancy_children` write strictly after every other on-action event has finished, so the mod's value always wins.

## Implementation notes

- `.0002` keeps the same `culture = { has_cultural_parameter = multi_birthing }` trigger, so we don't widen the scope of who runs the roll.
- `.0003` re-checks `scope:mother = { is_pregnant = yes }` defensively (a pregnancy can end in that 1-day window in pathological cases).
- The flag-clear block is preserved in `.0003` (a mother could carry a stale `having_X` flag from a prior pregnancy that ended without firing the cleanup).
- The random_list weights are unchanged.

## Test plan

- [ ] Load a save where an aeluran-cultured mother is pregnant; verify she eventually births the number of children matching the title.
- [ ] Repeat for a bastard pregnancy (the case where vanilla `pregnancy.2002` previously stomped the count).
- [ ] Repeat for a same-sex relationship pregnancy (`pregnancy.2050` path).
- [ ] Confirm single-child births still resolve normally (i.e. the random_list `21 = { set_num_pregnancy_children = 1 }` branch).
- [ ] Verify the `having_X` flag and child count agree in the birth event title and the actual children added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)