### PR TITLE
feat(maa/dynasty-legacies): add elven dynasty legacies and perks

### DIFF
--- a/common/dynasty_legacies/elf_dynasty_legacies.txt
+++ b/common/dynasty_legacies/elf_dynasty_legacies.txt
@@ -1,0 +1,53 @@
+﻿# valerith_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_valerith
+#             dynasty ?= dynasty:696970
+#         }
+# 	}
+# }
+
+# daelurin_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_daelurin
+#             dynasty ?= dynasty:696971
+#         }
+# 	}
+# }
+
+# serelion_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_serelion
+#             dynasty ?= dynasty:696972
+#         }
+# 	}
+# }
+
+# gwynthorn_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_gwynthorn
+#             dynasty ?= dynasty:696973
+#         }
+# 	}
+# }
+
+# thundarael_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_thundarael
+#             dynasty ?= dynasty:696974
+#         }
+# 	}
+# }
+
+# lormelis_legacy_track = {
+#     is_shown = {
+#         OR = {
+#             has_trait = royal_elf_lormelis
+#             dynasty ?= dynasty:696975
+#         }
+# 	}
+# }

--- a/common/dynasty_legacies/elf_dynasty_legacies.txt
+++ b/common/dynasty_legacies/elf_dynasty_legacies.txt
@@ -1,53 +1,53 @@
-﻿# valerith_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_valerith
-#             dynasty ?= dynasty:696970
-#         }
-# 	}
-# }
+valerith_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_valerith
+            dynasty ?= dynasty:696970
+        }
+	}
+}
 
-# daelurin_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_daelurin
-#             dynasty ?= dynasty:696971
-#         }
-# 	}
-# }
+daelurin_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_daelurin
+            dynasty ?= dynasty:696971
+        }
+	}
+}
 
-# serelion_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_serelion
-#             dynasty ?= dynasty:696972
-#         }
-# 	}
-# }
+serelion_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_serelion
+            dynasty ?= dynasty:696972
+        }
+	}
+}
 
-# gwynthorn_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_gwynthorn
-#             dynasty ?= dynasty:696973
-#         }
-# 	}
-# }
+gwynthorn_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_gwynthorn
+            dynasty ?= dynasty:696973
+        }
+	}
+}
 
-# thundarael_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_thundarael
-#             dynasty ?= dynasty:696974
-#         }
-# 	}
-# }
+thundarael_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_thundarael
+            dynasty ?= dynasty:696974
+        }
+	}
+}
 
-# lormelis_legacy_track = {
-#     is_shown = {
-#         OR = {
-#             has_trait = royal_elf_lormelis
-#             dynasty ?= dynasty:696975
-#         }
-# 	}
-# }
+lormelis_legacy_track = {
+    is_shown = {
+        OR = {
+            has_trait = royal_elf_lormelis
+            dynasty ?= dynasty:696975
+        }
+	}
+}

--- a/common/dynasty_perks/elf_dynasty_perks.txt
+++ b/common/dynasty_perks/elf_dynasty_perks.txt
@@ -1,0 +1,8 @@
+﻿# valerith_legacy_1 = {
+#     legacy = valerith_legacy_track
+#     can_be_picked = {
+#         is_valerith_trigger = yes
+#     }
+    
+# }
+

--- a/common/dynasty_perks/elf_dynasty_perks.txt
+++ b/common/dynasty_perks/elf_dynasty_perks.txt
@@ -1,8 +1,8 @@
-﻿# valerith_legacy_1 = {
-#     legacy = valerith_legacy_track
-#     can_be_picked = {
-#         is_valerith_trigger = yes
-#     }
+valerith_legacy_1 = {
+    legacy = valerith_legacy_track
+    can_be_picked = {
+        is_valerith_trigger = yes
+    }
     
-# }
+}
 

--- a/docs/superpowers/plans/2026-07-13-maa-expanded-integration.md
+++ b/docs/superpowers/plans/2026-07-13-maa-expanded-integration.md
@@ -1,0 +1,980 @@
+# MAA Expanded Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port all content from Elf-Destiny-MAA-Expanded into Elf-Destiny across 13 independent, reviewable branches — one per feature system.
+
+**Architecture:** Each task creates one git branch from `main`, copies the relevant files from the source repo, handles merges for the 3 files that already exist on `main`, commits, runs a code review, and pushes. All branches are independent and can be merged in any order.
+
+**Tech Stack:** CK3 Paradox script (.txt), YAML localization (.yml), DDS textures, git
+
+## Global Constraints
+
+- Source repo: `/work/mod/Elf-Destiny-MAA-Expanded`
+- Target repo: `/work/mod/Elf-Destiny`
+- All branches fork from `main` — never from each other
+- Run `/code-review` (superpowers:requesting-code-review skill) after every commit, before pushing
+- For 3 files that overlap with `main` (`elf_maa_types.txt`, `spark_maa_types.txt`, `elf_men_at_arms_values.txt`): diff first, merge manually, never overwrite blindly
+- Old `elf-destiny-maa` branch: leave untouched
+- Source abbreviation used throughout: `SRC=/work/mod/Elf-Destiny-MAA-Expanded`; `TGT=/work/mod/Elf-Destiny`
+- Verification shorthand used throughout: brace check = `python3 -c "t=open('FILE').read(); print('OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"`
+
+---
+
+### Task 1: Branch `maa/core`
+
+Core infrastructure: vanilla DLC MAA overrides, unit definitions, modifier formats, script values, general elf MAA types, base culture files, scripted triggers, core localization.
+
+**Files to create in target:**
+- `common/men_at_arms_types/00_cultural_maa_types.txt` (new)
+- `common/men_at_arms_types/00_fp3_maa_types.txt` (new)
+- `common/men_at_arms_types/00_maa_types.txt` (new)
+- `common/men_at_arms_types/00_regional_maa_types.txt` (new)
+- `common/men_at_arms_types/01_accolade_maa_types.txt` (new)
+- `common/men_at_arms_types/01_fp1_maa_types.txt` (new)
+- `common/men_at_arms_types/07_ep3_maa_types.txt` (new)
+- `common/men_at_arms_types/09_mpo_maa_types.txt` (new)
+- `common/men_at_arms_types/10_tgp_maa_types.txt` (new)
+- `common/men_at_arms_types/_men_at_arms_types.info` (new)
+- `common/men_at_arms_types/other_elf_maa_types.txt` (new)
+- `common/modifier_definition_formats/elf_unit_definitions.txt` (new)
+- `common/script_values/elite_elf_men_at_arms_values.txt` (new)
+- `common/script_values/elf_culture_values.txt` (new)
+- `common/scripted_effects/elf_families_triggers.txt` (new)
+- `common/culture/cultures/elf_cultures.txt` (new — MAA-Expanded version; verify no conflict with existing Elf-Destiny cultures file first)
+- `history/cultures/culture_elf.txt` (new — same caveat)
+- `localization/english/elf_culture_maa_l_english.yml` (new)
+- `localization/english/royal_elf_bloodlines_maa_l_english.yml` (new)
+
+**Files to merge (exist on main):**
+- `common/men_at_arms_types/elf_maa_types.txt`
+- `common/script_values/elf_men_at_arms_values.txt`
+
+- [ ] **Step 1: Verify no cultures/history conflict**
+
+```bash
+diff /work/mod/Elf-Destiny/common/culture/cultures/elf_cultures.txt \
+     /work/mod/Elf-Destiny-MAA-Expanded/common/culture/cultures/elf_cultures.txt 2>/dev/null \
+  && echo "FILES IDENTICAL" || echo "DIFFERENCES EXIST — review before copying"
+
+diff /work/mod/Elf-Destiny/history/cultures/culture_elf.txt \
+     /work/mod/Elf-Destiny-MAA-Expanded/history/cultures/culture_elf.txt 2>/dev/null \
+  && echo "FILES IDENTICAL" || echo "DIFFERENCES EXIST — review before copying"
+```
+
+If differences exist, open both files side by side and manually reconcile before proceeding.
+
+- [ ] **Step 2: Diff the two merge-required files**
+
+```bash
+diff /work/mod/Elf-Destiny/common/men_at_arms_types/elf_maa_types.txt \
+     /work/mod/Elf-Destiny-MAA-Expanded/common/men_at_arms_types/elf_maa_types.txt
+
+diff /work/mod/Elf-Destiny/common/script_values/elf_men_at_arms_values.txt \
+     /work/mod/Elf-Destiny-MAA-Expanded/common/script_values/elf_men_at_arms_values.txt
+```
+
+Read the diffs. Identify any blocks present in `main` that are absent from MAA-Expanded (content that Elf-Destiny added independently). Those blocks must be preserved in the merged result.
+
+- [ ] **Step 3: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/core
+```
+
+- [ ] **Step 4: Copy new files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/men_at_arms_types/00_cultural_maa_types.txt"  "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/00_fp3_maa_types.txt"       "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/00_maa_types.txt"           "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/00_regional_maa_types.txt"  "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/01_accolade_maa_types.txt"  "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/01_fp1_maa_types.txt"       "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/07_ep3_maa_types.txt"       "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/09_mpo_maa_types.txt"       "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/10_tgp_maa_types.txt"       "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/_men_at_arms_types.info"    "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/other_elf_maa_types.txt"    "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/modifier_definition_formats/elf_unit_definitions.txt" "$TGT/common/modifier_definition_formats/"
+cp "$SRC/common/script_values/elite_elf_men_at_arms_values.txt" "$TGT/common/script_values/"
+cp "$SRC/common/script_values/elf_culture_values.txt"          "$TGT/common/script_values/"
+cp "$SRC/common/scripted_effects/elf_families_triggers.txt"    "$TGT/common/scripted_effects/"
+cp "$SRC/common/culture/cultures/elf_cultures.txt"             "$TGT/common/culture/cultures/"
+cp "$SRC/history/cultures/culture_elf.txt"                     "$TGT/history/cultures/"
+cp "$SRC/localization/english/elf_culture_maa_l_english.yml"           "$TGT/localization/english/"
+cp "$SRC/localization/english/royal_elf_bloodlines_maa_l_english.yml"  "$TGT/localization/english/"
+```
+
+- [ ] **Step 5: Merge `elf_maa_types.txt` and `elf_men_at_arms_values.txt`**
+
+Using the diff output from Step 2, produce a merged version of each file that includes all content from MAA-Expanded plus any blocks unique to `main`. Edit the files directly in `$TGT`. Do not simply overwrite — preserve any Elf-Destiny-specific entries.
+
+- [ ] **Step 6: Verify files and brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+echo "=== File count ===" && ls "$TGT/common/men_at_arms_types/" | grep -c ""
+for f in \
+  "$TGT/common/men_at_arms_types/elf_maa_types.txt" \
+  "$TGT/common/men_at_arms_types/other_elf_maa_types.txt" \
+  "$TGT/common/modifier_definition_formats/elf_unit_definitions.txt" \
+  "$TGT/common/script_values/elf_men_at_arms_values.txt" \
+  "$TGT/common/script_values/elite_elf_men_at_arms_values.txt" \
+  "$TGT/common/scripted_effects/elf_families_triggers.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+All files should print `OK`. Fix any mismatch before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/men_at_arms_types/ common/modifier_definition_formats/elf_unit_definitions.txt \
+        common/script_values/elite_elf_men_at_arms_values.txt common/script_values/elf_culture_values.txt \
+        common/script_values/elf_men_at_arms_values.txt common/scripted_effects/elf_families_triggers.txt \
+        common/culture/cultures/elf_cultures.txt history/cultures/culture_elf.txt \
+        localization/english/elf_culture_maa_l_english.yml localization/english/royal_elf_bloodlines_maa_l_english.yml
+git commit -m "feat(maa/core): add core MAA infrastructure from Elf-Destiny-MAA-Expanded
+
+- Vanilla DLC MAA overrides (fp1, fp3, accolade, ep3, mpo, tgp)
+- Elf unit modifier definitions
+- Script values for MAA and culture
+- General elf MAA types and other_elf MAA types
+- Base culture and history files
+- Core MAA localization"
+```
+
+- [ ] **Step 8: Run code review, then push**
+
+Run `/code-review` on the current diff. Address any findings. Then:
+
+```bash
+git push -u origin maa/core
+```
+
+---
+
+### Task 2: Branch `maa/flying-units`
+
+Self-contained flying unit system: game concept definition, modifier definition format, modifiers localization.
+
+**Files to create in target (all new):**
+- `common/game_concepts/00_flying_units_game_concepts.txt`
+- `common/modifier_definition_formats/00_flying_units_unit_definitions.txt`
+- `localization/english/00_flying_units_maa_l_english.yml`
+- `localization/english/modifiers/flying_units_modifiers_l_english.yml`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/flying-units
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/game_concepts/00_flying_units_game_concepts.txt"              "$TGT/common/game_concepts/"
+cp "$SRC/common/modifier_definition_formats/00_flying_units_unit_definitions.txt" "$TGT/common/modifier_definition_formats/"
+cp "$SRC/localization/english/00_flying_units_maa_l_english.yml"              "$TGT/localization/english/"
+cp "$SRC/localization/english/modifiers/flying_units_modifiers_l_english.yml" "$TGT/localization/english/modifiers/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/game_concepts/00_flying_units_game_concepts.txt" \
+  "$TGT/common/modifier_definition_formats/00_flying_units_unit_definitions.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/game_concepts/00_flying_units_game_concepts.txt \
+        common/modifier_definition_formats/00_flying_units_unit_definitions.txt \
+        localization/english/00_flying_units_maa_l_english.yml \
+        localization/english/modifiers/flying_units_modifiers_l_english.yml
+git commit -m "feat(maa/flying-units): add flying units system from Elf-Destiny-MAA-Expanded
+
+Game concept definition, unit modifier format, and localization
+for the flying units MAA system."
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/flying-units
+```
+
+---
+
+### Task 3: Branch `maa/elven-professionalism`
+
+Elven Professionalism system: tradition, decisions, MAA types, modifiers, scripted effects, and all localization.
+
+**Files to create in target (all new):**
+- `common/culture/traditions/elven_professionalism_tradition.txt`
+- `common/decisions/elven_professionalism_decisions.txt`
+- `common/men_at_arms_types/elven_professionalism_maa_types.txt`
+- `common/modifiers/elven_professionalism_modifiers.txt`
+- `common/scripted_effects/elven_professionalism_tradition_effects.txt`
+- `localization/english/culture/traditions/elven_professionalism_traditions_l_english.yml`
+- `localization/english/decisions/elven_professionalism_decisions_l_english.yml`
+- `localization/english/modifiers/elven_professionalism_modifiers_l_english.yml`
+
+- [ ] **Step 1: Create branch and any missing directories**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/elven-professionalism
+mkdir -p localization/english/culture/traditions
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/culture/traditions/elven_professionalism_tradition.txt"   "$TGT/common/culture/traditions/"
+cp "$SRC/common/decisions/elven_professionalism_decisions.txt"             "$TGT/common/decisions/"
+cp "$SRC/common/men_at_arms_types/elven_professionalism_maa_types.txt"    "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/modifiers/elven_professionalism_modifiers.txt"             "$TGT/common/modifiers/"
+cp "$SRC/common/scripted_effects/elven_professionalism_tradition_effects.txt" "$TGT/common/scripted_effects/"
+cp "$SRC/localization/english/culture/traditions/elven_professionalism_traditions_l_english.yml" \
+   "$TGT/localization/english/culture/traditions/"
+cp "$SRC/localization/english/decisions/elven_professionalism_decisions_l_english.yml" \
+   "$TGT/localization/english/decisions/"
+cp "$SRC/localization/english/modifiers/elven_professionalism_modifiers_l_english.yml" \
+   "$TGT/localization/english/modifiers/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/culture/traditions/elven_professionalism_tradition.txt" \
+  "$TGT/common/decisions/elven_professionalism_decisions.txt" \
+  "$TGT/common/men_at_arms_types/elven_professionalism_maa_types.txt" \
+  "$TGT/common/modifiers/elven_professionalism_modifiers.txt" \
+  "$TGT/common/scripted_effects/elven_professionalism_tradition_effects.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/culture/traditions/elven_professionalism_tradition.txt \
+        common/decisions/elven_professionalism_decisions.txt \
+        common/men_at_arms_types/elven_professionalism_maa_types.txt \
+        common/modifiers/elven_professionalism_modifiers.txt \
+        common/scripted_effects/elven_professionalism_tradition_effects.txt \
+        localization/english/culture/traditions/elven_professionalism_traditions_l_english.yml \
+        localization/english/decisions/elven_professionalism_decisions_l_english.yml \
+        localization/english/modifiers/elven_professionalism_modifiers_l_english.yml
+git commit -m "feat(maa/elven-professionalism): add Elven Professionalism system from MAA-Expanded
+
+Tradition, decisions, dedicated MAA types, modifiers, scripted
+effects, and full English localization."
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/elven-professionalism
+```
+
+---
+
+### Task 4: Branch `maa/innovations`
+
+MAA-specific culture innovations and cultural parameters localization.
+
+**Files to create in target (all new):**
+- `common/culture/innovations/elf_maa_innovations.txt`
+- `localization/english/culture/elf_maa_cultural_innovations_l_english.yml`
+- `localization/english/culture/elf_maa_cultural_parameters_l_english.yml`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/innovations
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/culture/innovations/elf_maa_innovations.txt"                     "$TGT/common/culture/innovations/"
+cp "$SRC/localization/english/culture/elf_maa_cultural_innovations_l_english.yml" "$TGT/localization/english/culture/"
+cp "$SRC/localization/english/culture/elf_maa_cultural_parameters_l_english.yml"  "$TGT/localization/english/culture/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+python3 -c "t=open('$TGT/common/culture/innovations/elf_maa_innovations.txt').read(); print('OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/culture/innovations/elf_maa_innovations.txt \
+        localization/english/culture/elf_maa_cultural_innovations_l_english.yml \
+        localization/english/culture/elf_maa_cultural_parameters_l_english.yml
+git commit -m "feat(maa/innovations): add MAA culture innovations from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/innovations
+```
+
+---
+
+### Task 5: Branch `maa/dynasty-legacies`
+
+Dynasty legacies, dynasty perks, and per-culture legacy localization.
+
+**Files to create in target (all new; directories need creating):**
+- `common/dynasty_legacies/elf_dynasty_legacies.txt`
+- `common/dynasty_perks/elf_dynasty_perks.txt`
+- `localization/english/legacies/daelurin_legacy_l_english.yml`
+- `localization/english/legacies/gwynthorn_legacy_l_english.yml`
+- `localization/english/legacies/lormelis_legacy_l_english.yml`
+- `localization/english/legacies/serelion_legacy_l_english.yml`
+- `localization/english/legacies/thundarael_legacy_l_english.yml`
+- `localization/english/legacies/valerith_legacy_l_english.yml`
+
+- [ ] **Step 1: Create branch and missing directories**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/dynasty-legacies
+mkdir -p common/dynasty_legacies common/dynasty_perks localization/english/legacies
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/dynasty_legacies/elf_dynasty_legacies.txt" "$TGT/common/dynasty_legacies/"
+cp "$SRC/common/dynasty_perks/elf_dynasty_perks.txt"       "$TGT/common/dynasty_perks/"
+cp "$SRC/localization/english/legacies/"*_l_english.yml    "$TGT/localization/english/legacies/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/dynasty_legacies/elf_dynasty_legacies.txt" \
+  "$TGT/common/dynasty_perks/elf_dynasty_perks.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+echo "Loc files copied:" && ls /work/mod/Elf-Destiny/localization/english/legacies/ | wc -l
+```
+
+Expected: both script files `OK`, loc count = 6.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/dynasty_legacies/ common/dynasty_perks/ localization/english/legacies/
+git commit -m "feat(maa/dynasty-legacies): add dynasty legacies and perks from Elf-Destiny-MAA-Expanded
+
+Per-culture dynasty legacies (daelurin, gwynthorn, lormelis,
+serelion, thundarael, valerith) and dynasty perks."
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/dynasty-legacies
+```
+
+---
+
+### Task 6: Branch `maa/traditions`
+
+Culture-specific traditions, spark path tradition, tradition scripted effects, and tradition icon DDS files.
+
+**Files to create in target:**
+- `common/culture/traditions/elf_specific_cultural_traditions.txt` (new)
+- `common/culture/traditions/spark_path_of_baddie.txt` (new)
+- `common/scripted_effects/culture_tradition_effects.txt` (new)
+- 18 DDS files in `gfx/interface/icons/culture_tradition/4-items/`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/traditions
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/culture/traditions/elf_specific_cultural_traditions.txt" "$TGT/common/culture/traditions/"
+cp "$SRC/common/culture/traditions/spark_path_of_baddie.txt"             "$TGT/common/culture/traditions/"
+cp "$SRC/common/scripted_effects/culture_tradition_effects.txt"           "$TGT/common/scripted_effects/"
+cp "$SRC/gfx/interface/icons/culture_tradition/4-items/"*.dds            "$TGT/gfx/interface/icons/culture_tradition/4-items/"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/culture/traditions/elf_specific_cultural_traditions.txt" \
+  "$TGT/common/culture/traditions/spark_path_of_baddie.txt" \
+  "$TGT/common/scripted_effects/culture_tradition_effects.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+echo "Tradition DDS count:" && ls "$TGT/gfx/interface/icons/culture_tradition/4-items/" | grep "^tradition_" | wc -l
+```
+
+Expected: all script files `OK`, DDS count ≥ 18.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/culture/traditions/elf_specific_cultural_traditions.txt \
+        common/culture/traditions/spark_path_of_baddie.txt \
+        common/scripted_effects/culture_tradition_effects.txt \
+        "gfx/interface/icons/culture_tradition/4-items/"
+git commit -m "feat(maa/traditions): add culture traditions and tradition icons from Elf-Destiny-MAA-Expanded
+
+Elf-specific cultural traditions, Spark path tradition, tradition
+scripted effects, and 18 culture tradition icon DDS files."
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/traditions
+```
+
+---
+
+### Task 7: Branch `maa/expedition-events`
+
+Three expedition activity event files and their localization.
+
+**Files to create in target (all new):**
+- `events/activities/expedition_activity/expedition_events.txt`
+- `events/activities/expedition_activity/expedition_riddles.txt`
+- `events/activities/expedition_activity/expedition_unique_encounters.txt`
+- `localization/english/events/event_localization/expedition_l_english.yml`
+
+Note: Check whether any of these files already exist in `$TGT/events/activities/expedition_activity/` before copying.
+
+- [ ] **Step 1: Check for existing files and create branch**
+
+```bash
+ls /work/mod/Elf-Destiny/events/activities/expedition_activity/
+```
+
+If `expedition_events.txt`, `expedition_riddles.txt`, or `expedition_unique_encounters.txt` already exist, diff them against the MAA-Expanded versions before overwriting.
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/expedition-events
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/events/activities/expedition_activity/expedition_events.txt"          "$TGT/events/activities/expedition_activity/"
+cp "$SRC/events/activities/expedition_activity/expedition_riddles.txt"         "$TGT/events/activities/expedition_activity/"
+cp "$SRC/events/activities/expedition_activity/expedition_unique_encounters.txt" "$TGT/events/activities/expedition_activity/"
+cp "$SRC/localization/english/events/event_localization/expedition_l_english.yml" "$TGT/localization/english/events/event_localization/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/events/activities/expedition_activity/expedition_events.txt" \
+  "$TGT/events/activities/expedition_activity/expedition_riddles.txt" \
+  "$TGT/events/activities/expedition_activity/expedition_unique_encounters.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add events/activities/expedition_activity/expedition_events.txt \
+        events/activities/expedition_activity/expedition_riddles.txt \
+        events/activities/expedition_activity/expedition_unique_encounters.txt \
+        localization/english/events/event_localization/expedition_l_english.yml
+git commit -m "feat(maa/expedition-events): add expedition events from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/expedition-events
+```
+
+---
+
+### Task 8: Branch `maa/gui`
+
+Single GUI file for MAA text icons.
+
+**Files to create in target (new):**
+- `gui/elf_maa_texticons.gui`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/gui
+```
+
+- [ ] **Step 2: Copy file**
+
+```bash
+cp /work/mod/Elf-Destiny-MAA-Expanded/gui/elf_maa_texticons.gui \
+   /work/mod/Elf-Destiny/gui/
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+python3 -c "t=open('/work/mod/Elf-Destiny/gui/elf_maa_texticons.gui').read(); print('OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add gui/elf_maa_texticons.gui
+git commit -m "feat(maa/gui): add MAA text icons GUI file from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/gui
+```
+
+---
+
+### Task 9: Branch `maa/assets`
+
+All DDS binary assets: regiment type icons and both illustration sizes. No script files.
+
+**Files to create in target:**
+- ~80 files in `gfx/interface/icons/regimenttypes/`
+- ~60 files in `gfx/interface/illustrations/men_at_arms_big/`
+- ~60 files in `gfx/interface/illustrations/men_at_arms_small/`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/assets
+```
+
+- [ ] **Step 2: Copy all DDS asset files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/gfx/interface/icons/regimenttypes/"*.dds              "$TGT/gfx/interface/icons/regimenttypes/"
+cp "$SRC/gfx/interface/illustrations/men_at_arms_big/"*.dds   "$TGT/gfx/interface/illustrations/men_at_arms_big/"
+cp "$SRC/gfx/interface/illustrations/men_at_arms_small/"*.dds "$TGT/gfx/interface/illustrations/men_at_arms_small/"
+```
+
+- [ ] **Step 3: Verify counts**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+echo "regimenttypes — src:" $(ls "$SRC/gfx/interface/icons/regimenttypes/"*.dds | wc -l) \
+     "tgt:" $(ls "$TGT/gfx/interface/icons/regimenttypes/"*.dds | wc -l)
+echo "maa_big — src:"       $(ls "$SRC/gfx/interface/illustrations/men_at_arms_big/"*.dds | wc -l) \
+     "tgt:" $(ls "$TGT/gfx/interface/illustrations/men_at_arms_big/"*.dds | wc -l)
+echo "maa_small — src:"     $(ls "$SRC/gfx/interface/illustrations/men_at_arms_small/"*.dds | wc -l) \
+     "tgt:" $(ls "$TGT/gfx/interface/illustrations/men_at_arms_small/"*.dds | wc -l)
+```
+
+Target counts should be ≥ source counts (target may already have some files from `main`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add gfx/interface/icons/regimenttypes/ \
+        gfx/interface/illustrations/men_at_arms_big/ \
+        gfx/interface/illustrations/men_at_arms_small/
+git commit -m "feat(maa/assets): add all MAA DDS assets from Elf-Destiny-MAA-Expanded
+
+Regiment type icons, large illustrations, and small illustrations
+for all MAA units added by the MAA Expanded mod."
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. For an assets-only commit this will be brief — reviewer should confirm no unexpected non-DDS files snuck in. Then:
+
+```bash
+git push -u origin maa/assets
+```
+
+---
+
+### Task 10: Branch `maa/cultures-group-1` (alfar, astrion, atlareth)
+
+MAA type definitions for the first culture group.
+
+**Files to create in target (all new):**
+- `common/men_at_arms_types/alfar_maa.txt`
+- `common/men_at_arms_types/astrion_maa.txt`
+- `common/men_at_arms_types/atlareth_maa.txt`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/cultures-group-1
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/men_at_arms_types/alfar_maa.txt"   "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/astrion_maa.txt" "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/atlareth_maa.txt" "$TGT/common/men_at_arms_types/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/men_at_arms_types/alfar_maa.txt" \
+  "$TGT/common/men_at_arms_types/astrion_maa.txt" \
+  "$TGT/common/men_at_arms_types/atlareth_maa.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/men_at_arms_types/alfar_maa.txt \
+        common/men_at_arms_types/astrion_maa.txt \
+        common/men_at_arms_types/atlareth_maa.txt
+git commit -m "feat(maa/cultures-group-1): add alfar, astrion, atlareth MAA types from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/cultures-group-1
+```
+
+---
+
+### Task 11: Branch `maa/cultures-group-2` (daelurin, deepwood, gwynthorn)
+
+MAA type definitions and history culture files for the second culture group.
+
+**Files to create in target (all new):**
+- `common/men_at_arms_types/daelurin_maa_types.txt`
+- `common/men_at_arms_types/deepwood_elven_maa.txt`
+- `common/men_at_arms_types/gwynthorn_maa_types.txt`
+- `history/cultures/elf_culture_daelurin.txt`
+- `history/cultures/elf_culture_gwynthorn.txt`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/cultures-group-2
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/men_at_arms_types/daelurin_maa_types.txt" "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/deepwood_elven_maa.txt"  "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/gwynthorn_maa_types.txt" "$TGT/common/men_at_arms_types/"
+cp "$SRC/history/cultures/elf_culture_daelurin.txt"        "$TGT/history/cultures/"
+cp "$SRC/history/cultures/elf_culture_gwynthorn.txt"       "$TGT/history/cultures/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/men_at_arms_types/daelurin_maa_types.txt" \
+  "$TGT/common/men_at_arms_types/deepwood_elven_maa.txt" \
+  "$TGT/common/men_at_arms_types/gwynthorn_maa_types.txt" \
+  "$TGT/history/cultures/elf_culture_daelurin.txt" \
+  "$TGT/history/cultures/elf_culture_gwynthorn.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/men_at_arms_types/daelurin_maa_types.txt \
+        common/men_at_arms_types/deepwood_elven_maa.txt \
+        common/men_at_arms_types/gwynthorn_maa_types.txt \
+        history/cultures/elf_culture_daelurin.txt \
+        history/cultures/elf_culture_gwynthorn.txt
+git commit -m "feat(maa/cultures-group-2): add daelurin, deepwood, gwynthorn MAA types from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/cultures-group-2
+```
+
+---
+
+### Task 12: Branch `maa/cultures-group-3` (lormelis, romaviri, serelion)
+
+MAA type definitions and history culture files for the third culture group.
+
+**Files to create in target (all new):**
+- `common/men_at_arms_types/lormelis_maa_types.txt`
+- `common/men_at_arms_types/romaviri_maa.txt`
+- `common/men_at_arms_types/serelion_maa_types.txt`
+- `history/cultures/elf_culture_lormelis.txt`
+- `history/cultures/elf_culture_serelion.txt`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/cultures-group-3
+```
+
+- [ ] **Step 2: Copy files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/men_at_arms_types/lormelis_maa_types.txt" "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/romaviri_maa.txt"        "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/serelion_maa_types.txt"  "$TGT/common/men_at_arms_types/"
+cp "$SRC/history/cultures/elf_culture_lormelis.txt"        "$TGT/history/cultures/"
+cp "$SRC/history/cultures/elf_culture_serelion.txt"        "$TGT/history/cultures/"
+```
+
+- [ ] **Step 3: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/men_at_arms_types/lormelis_maa_types.txt" \
+  "$TGT/common/men_at_arms_types/romaviri_maa.txt" \
+  "$TGT/common/men_at_arms_types/serelion_maa_types.txt" \
+  "$TGT/history/cultures/elf_culture_lormelis.txt" \
+  "$TGT/history/cultures/elf_culture_serelion.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/men_at_arms_types/lormelis_maa_types.txt \
+        common/men_at_arms_types/romaviri_maa.txt \
+        common/men_at_arms_types/serelion_maa_types.txt \
+        history/cultures/elf_culture_lormelis.txt \
+        history/cultures/elf_culture_serelion.txt
+git commit -m "feat(maa/cultures-group-3): add lormelis, romaviri, serelion MAA types from Elf-Destiny-MAA-Expanded"
+```
+
+- [ ] **Step 5: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/cultures-group-3
+```
+
+---
+
+### Task 13: Branch `maa/cultures-group-4` (thundarael, tuathan, valerith, spark)
+
+MAA type definitions and history culture files for the fourth culture group. Includes `spark_maa_types.txt` which already exists on `main` and must be merged, not overwritten.
+
+**Files to create in target:**
+- `common/men_at_arms_types/thundarael_maa_types.txt` (new)
+- `common/men_at_arms_types/tuathan_maa.txt` (new)
+- `common/men_at_arms_types/valerith_maa_types.txt` (new)
+- `history/cultures/elf_culture_thundarael.txt` (new)
+- `history/cultures/elf_culture_valerith.txt` (new)
+- `common/men_at_arms_types/spark_maa_types.txt` (**merge required**)
+
+- [ ] **Step 1: Diff `spark_maa_types.txt`**
+
+```bash
+diff /work/mod/Elf-Destiny/common/men_at_arms_types/spark_maa_types.txt \
+     /work/mod/Elf-Destiny-MAA-Expanded/common/men_at_arms_types/spark_maa_types.txt
+```
+
+Read the diff. Identify any content unique to `main` that must be preserved. Plan the manual merge.
+
+- [ ] **Step 2: Create branch**
+
+```bash
+cd /work/mod/Elf-Destiny
+git checkout main
+git checkout -b maa/cultures-group-4
+```
+
+- [ ] **Step 3: Copy new files**
+
+```bash
+SRC=/work/mod/Elf-Destiny-MAA-Expanded
+TGT=/work/mod/Elf-Destiny
+
+cp "$SRC/common/men_at_arms_types/thundarael_maa_types.txt" "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/tuathan_maa.txt"           "$TGT/common/men_at_arms_types/"
+cp "$SRC/common/men_at_arms_types/valerith_maa_types.txt"    "$TGT/common/men_at_arms_types/"
+cp "$SRC/history/cultures/elf_culture_thundarael.txt"        "$TGT/history/cultures/"
+cp "$SRC/history/cultures/elf_culture_valerith.txt"          "$TGT/history/cultures/"
+```
+
+- [ ] **Step 4: Merge `spark_maa_types.txt`**
+
+Using the diff from Step 1, manually edit `$TGT/common/men_at_arms_types/spark_maa_types.txt` to incorporate MAA-Expanded's changes while preserving any Elf-Destiny-specific content. Do not use `cp` — edit in place.
+
+- [ ] **Step 5: Verify brace balance**
+
+```bash
+TGT=/work/mod/Elf-Destiny
+for f in \
+  "$TGT/common/men_at_arms_types/thundarael_maa_types.txt" \
+  "$TGT/common/men_at_arms_types/tuathan_maa.txt" \
+  "$TGT/common/men_at_arms_types/valerith_maa_types.txt" \
+  "$TGT/common/men_at_arms_types/spark_maa_types.txt" \
+  "$TGT/history/cultures/elf_culture_thundarael.txt" \
+  "$TGT/history/cultures/elf_culture_valerith.txt"
+do
+  python3 -c "t=open('$f').read(); print('$f:', 'OK' if t.count('{') == t.count('}') else 'MISMATCH', t.count('{'), t.count('}'))"
+done
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/mod/Elf-Destiny
+git add common/men_at_arms_types/thundarael_maa_types.txt \
+        common/men_at_arms_types/tuathan_maa.txt \
+        common/men_at_arms_types/valerith_maa_types.txt \
+        common/men_at_arms_types/spark_maa_types.txt \
+        history/cultures/elf_culture_thundarael.txt \
+        history/cultures/elf_culture_valerith.txt
+git commit -m "feat(maa/cultures-group-4): add thundarael, tuathan, valerith, spark MAA types from Elf-Destiny-MAA-Expanded
+
+spark_maa_types.txt manually merged to preserve existing
+Elf-Destiny content."
+```
+
+- [ ] **Step 7: Run code review, then push**
+
+Run `/code-review`. Address findings. Then:
+
+```bash
+git push -u origin maa/cultures-group-4
+```

--- a/docs/superpowers/specs/2026-07-13-maa-expanded-integration-design.md
+++ b/docs/superpowers/specs/2026-07-13-maa-expanded-integration-design.md
@@ -1,0 +1,80 @@
+# Elf Destiny MAA Expanded Integration — Design Spec
+
+**Date:** 2026-07-13  
+**Source repo:** `Elf-Destiny-MAA-Expanded` (at `/work/mod/Elf-Destiny-MAA-Expanded`)  
+**Target repo:** `Elf-Destiny` (at `/work/mod/Elf-Destiny`)
+
+---
+
+## Goal
+
+Integrate the full content of the Elf-Destiny-MAA-Expanded mod into the Elf-Destiny repo by creating 13 independent, reviewable branches — one per feature system. The old `elf-destiny-maa` branch is outdated and will be left as-is (not deleted, not rebased).
+
+---
+
+## Branch Structure
+
+All 13 branches fork from `main`. They are independent of each other and can be reviewed and merged in any order.
+
+| # | Branch | Contents |
+|---|--------|----------|
+| 1 | `maa/core` | Vanilla DLC MAA overrides (`00_fp3`, `01_accolade`, `01_fp1`, `07_ep3`, `09_mpo`, `10_tgp`, `_men_at_arms_types.info`), unit/modifier definition format (`elf_unit_definitions.txt`), script values (`elf_men_at_arms_values.txt`, `elite_elf_men_at_arms_values.txt`, `elf_culture_values.txt`), general elf MAA types (`elf_maa_types.txt`, `other_elf_maa_types.txt`), base culture files (`elf_cultures.txt`, `history/cultures/culture_elf.txt`), `elf_families_triggers.txt`, localization for core MAA (`elf_culture_maa_l_english.yml`, `royal_elf_bloodlines_maa_l_english.yml`) |
+| 2 | `maa/flying-units` | `00_flying_units_game_concepts.txt`, `00_flying_units_unit_definitions.txt` (modifier definition format), `flying_units_modifiers_l_english.yml`, `00_flying_units_maa_l_english.yml` |
+| 3 | `maa/elven-professionalism` | `elven_professionalism_tradition.txt`, `elven_professionalism_decisions.txt`, `elven_professionalism_maa_types.txt`, `elven_professionalism_modifiers.txt`, `elven_professionalism_tradition_effects.txt`, all elven professionalism localization |
+| 4 | `maa/innovations` | `elf_maa_innovations.txt`, `elf_maa_cultural_innovations_l_english.yml`, `elf_maa_cultural_parameters_l_english.yml` |
+| 5 | `maa/dynasty-legacies` | `elf_dynasty_legacies.txt`, `elf_dynasty_perks.txt`, all `localization/english/legacies/` files |
+| 6 | `maa/traditions` | `elf_specific_cultural_traditions.txt`, `spark_path_of_baddie.txt`, `culture_tradition_effects.txt`, all `gfx/interface/icons/culture_tradition/4-items/` DDS files |
+| 7 | `maa/expedition-events` | `expedition_events.txt`, `expedition_riddles.txt`, `expedition_unique_encounters.txt`, `expedition_l_english.yml` |
+| 8 | `maa/gui` | `gui/elf_maa_texticons.gui` |
+| 9 | `maa/assets` | All `gfx/interface/icons/regimenttypes/` DDS files, all `gfx/interface/illustrations/men_at_arms_big/` DDS files, all `gfx/interface/illustrations/men_at_arms_small/` DDS files |
+| 10 | `maa/cultures-group-1` | alfar, astrion, atlareth — MAA type files, history culture files, legacy localization, regiment icons |
+| 11 | `maa/cultures-group-2` | daelurin, deepwood, gwynthorn — MAA type files, history culture files, legacy localization, regiment icons |
+| 12 | `maa/cultures-group-3` | lormelis, romaviri, serelion — MAA type files, history culture files, legacy localization, regiment icons |
+| 13 | `maa/cultures-group-4` | thundarael, tuathan, valerith, spark — MAA type files, history culture files, legacy localization, regiment icons |
+
+---
+
+## Special Cases
+
+### `spark_maa_types.txt`
+This file already exists on `Elf-Destiny/main`. Before adding it to `maa/cultures-group-4`, diff the two versions and carry over only the changes from MAA-Expanded (rather than blindly overwriting).
+
+### `elf_men_at_arms_values.txt`
+Also exists on `Elf-Destiny/main`. Same treatment — diff and merge, don't overwrite.
+
+### `elf_maa_types.txt`
+Also exists on `Elf-Destiny/main`. Diff and merge.
+
+### Old `elf-destiny-maa` branch
+Leave it in place. It is not deleted, rebased, or referenced by any of the new branches.
+
+---
+
+## Branch Creation Process (per branch)
+
+For each branch:
+1. `git checkout main && git checkout -b <branch-name>`
+2. Copy the relevant files from `Elf-Destiny-MAA-Expanded` into the correct paths in `Elf-Destiny`
+3. For files that already exist on `main`, diff first and merge carefully
+4. `git add` only the files for that branch
+5. Commit with a descriptive message referencing the source mod
+6. Push to remote (`origin`)
+
+---
+
+## Files That Exist on Both Repos (need diff/merge)
+
+| File | Elf-Destiny/main | MAA-Expanded |
+|------|-----------------|--------------|
+| `common/men_at_arms_types/elf_maa_types.txt` | exists | exists (updated) |
+| `common/men_at_arms_types/spark_maa_types.txt` | exists | exists (updated) |
+| `common/script_values/elf_men_at_arms_values.txt` | exists | exists (updated) |
+
+---
+
+## Out of Scope
+
+- Localization for languages other than English (Korean, Spanish) — not present in MAA-Expanded
+- Any changes to the `Elf-Destiny-MAA-Expanded` repo itself
+- Merging any of the 13 branches into `main` (that is a separate review decision)
+- Rebasing or cleaning up the old `elf-destiny-maa` branch

--- a/docs/superpowers/specs/2026-07-13-maa-expanded-integration-design.md
+++ b/docs/superpowers/specs/2026-07-13-maa-expanded-integration-design.md
@@ -58,7 +58,8 @@ For each branch:
 3. For files that already exist on `main`, diff first and merge carefully
 4. `git add` only the files for that branch
 5. Commit with a descriptive message referencing the source mod
-6. Push to remote (`origin`)
+6. **Run `/code-review` (superpowers requesting-code-review skill) on the commit before pushing** — catch logic errors, missing loc keys, bad references, or structural issues early
+7. Push to remote (`origin`)
 
 ---
 

--- a/localization/english/legacies/daelurin_legacy_l_english.yml
+++ b/localization/english/legacies/daelurin_legacy_l_english.yml
@@ -1,21 +1,21 @@
-﻿# l_english:
-#  daelurin_legacy_track_name: "House Daelurin"
-#  daelurin_legacy_track_desc: "From the mountains of shadow and starlight come the towering warriors of Daelurin, bred for battle, mastery of the blade, and supernatural feats of might. Their bloodlines produce beings of immense physical power, whose war-cries shake the hearts of men."
+l_english:
+ daelurin_legacy_track_name: "House Daelurin"
+ daelurin_legacy_track_desc: "From the mountains of shadow and starlight come the towering warriors of Daelurin, bred for battle, mastery of the blade, and supernatural feats of might. Their bloodlines produce beings of immense physical power, whose war-cries shake the hearts of men."
 
-#  daelurin_legacy_1_name: "Waking the Blood"
-#  daelurin_legacy_2_name: "Iron Discipline"
-#  daelurin_legacy_3_name: "Art of War"
-#  daelurin_legacy_4_name: "Crushing Blows"
-#  daelurin_legacy_5_name: "Living Legends"
+ daelurin_legacy_1_name: "Waking the Blood"
+ daelurin_legacy_2_name: "Iron Discipline"
+ daelurin_legacy_3_name: "Art of War"
+ daelurin_legacy_4_name: "Crushing Blows"
+ daelurin_legacy_5_name: "Living Legends"
 
-#  LEGACY_DYNASTY_DAELURIN_UNLOCK_UNITS: "Unlocks the [GetMaA('️daelurin_whitevale_warriors').GetName], [GetMaA('wolf_riders').GetName], and [GetMaA('daelurin_highlanders').GetName] [men_at_arms|E] unique to House Daelurin"
+ LEGACY_DYNASTY_DAELURIN_UNLOCK_UNITS: "Unlocks the [GetMaA('daelurin_whitevale_warriors').GetName], [GetMaA('wolf_riders').GetName], and [GetMaA('daelurin_highlanders').GetName] [men_at_arms|E] unique to House Daelurin"
 
-#  LEGACY_DYNASTY_DAELURIN_WAKING_THE_BLOOD: "[prowess|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('strong').GetName] or [GetTrait('giant').GetName] traits"
+ LEGACY_DYNASTY_DAELURIN_WAKING_THE_BLOOD: "[prowess|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('strong').GetName] or [GetTrait('giant').GetName] traits"
 
-#  LEGACY_DYNASTY_DAELURIN_IRON_DISCIPLINE: "[knight_effectiveness|E]: #P +15%#! and [men_at_arms_damage_mult|E]: #P +5%#!"
+ LEGACY_DYNASTY_DAELURIN_IRON_DISCIPLINE: "[knight_effectiveness|E]: #P +15%#! and [men_at_arms_damage_mult|E]: #P +5%#!"
 
-#  LEGACY_DYNASTY_DAELURIN_ART_OF_WAR: "[martial_lifestyle_experience|E]: #P +15%#! and monthly [prestige|E]: #P +10%#!"
+ LEGACY_DYNASTY_DAELURIN_ART_OF_WAR: "[martial_lifestyle_experience|E]: #P +15%#! and monthly [prestige|E]: #P +10%#!"
 
-#  LEGACY_DYNASTY_DAELURIN_CRUSHING_BLOWS: "[knight_damage_mult|E]: #P +25%#! and [enemy_combat_pursuit_damage_taken_mult|E]: #P +10%#!"
+ LEGACY_DYNASTY_DAELURIN_CRUSHING_BLOWS: "[knight_damage_mult|E]: #P +25%#! and [enemy_combat_pursuit_damage_taken_mult|E]: #P +10%#!"
 
-#  LEGACY_DYNASTY_DAELURIN_LIVING_LEGENDS_EFFECT: "Increased chance for [dynasty_members|E] to be born with [GetTrait('strong').GetName], [GetTrait('giant').GetName], or [GetTrait('quick').GetName]; unlocks the ability to commission heroic statues to their feats"
+ LEGACY_DYNASTY_DAELURIN_LIVING_LEGENDS_EFFECT: "Increased chance for [dynasty_members|E] to be born with [GetTrait('strong').GetName], [GetTrait('giant').GetName], or [GetTrait('quick').GetName]; unlocks the ability to commission heroic statues to their feats"

--- a/localization/english/legacies/daelurin_legacy_l_english.yml
+++ b/localization/english/legacies/daelurin_legacy_l_english.yml
@@ -1,0 +1,21 @@
+﻿# l_english:
+#  daelurin_legacy_track_name: "House Daelurin"
+#  daelurin_legacy_track_desc: "From the mountains of shadow and starlight come the towering warriors of Daelurin, bred for battle, mastery of the blade, and supernatural feats of might. Their bloodlines produce beings of immense physical power, whose war-cries shake the hearts of men."
+
+#  daelurin_legacy_1_name: "Waking the Blood"
+#  daelurin_legacy_2_name: "Iron Discipline"
+#  daelurin_legacy_3_name: "Art of War"
+#  daelurin_legacy_4_name: "Crushing Blows"
+#  daelurin_legacy_5_name: "Living Legends"
+
+#  LEGACY_DYNASTY_DAELURIN_UNLOCK_UNITS: "Unlocks the [GetMaA('️daelurin_whitevale_warriors').GetName], [GetMaA('wolf_riders').GetName], and [GetMaA('daelurin_highlanders').GetName] [men_at_arms|E] unique to House Daelurin"
+
+#  LEGACY_DYNASTY_DAELURIN_WAKING_THE_BLOOD: "[prowess|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('strong').GetName] or [GetTrait('giant').GetName] traits"
+
+#  LEGACY_DYNASTY_DAELURIN_IRON_DISCIPLINE: "[knight_effectiveness|E]: #P +15%#! and [men_at_arms_damage_mult|E]: #P +5%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_ART_OF_WAR: "[martial_lifestyle_experience|E]: #P +15%#! and monthly [prestige|E]: #P +10%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_CRUSHING_BLOWS: "[knight_damage_mult|E]: #P +25%#! and [enemy_combat_pursuit_damage_taken_mult|E]: #P +10%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_LIVING_LEGENDS_EFFECT: "Increased chance for [dynasty_members|E] to be born with [GetTrait('strong').GetName], [GetTrait('giant').GetName], or [GetTrait('quick').GetName]; unlocks the ability to commission heroic statues to their feats"

--- a/localization/english/legacies/gwynthorn_legacy_l_english.yml
+++ b/localization/english/legacies/gwynthorn_legacy_l_english.yml
@@ -1,0 +1,20 @@
+﻿# l_english:
+
+#  gwynthorn_legacy_track_name: "House Gwynthorn"
+#  gwynthorn_legacy_track_desc: "Tireless stewards and diligent caretakers, the Gwynthorn bloodline is marked by boundless energy, industrious hearts, and an unwavering commitment to the prosperity of their lands. Fields flourish and halls gleam wherever their kin dwell."
+
+#  gwynthorn_legacy_1_name: "Tiller's Heritage"
+#  gwynthorn_legacy_2_name: "Relentless Labor"
+#  gwynthorn_legacy_3_name: "Stone and Root"
+#  gwynthorn_legacy_4_name: "Golden Harvests"
+#  gwynthorn_legacy_5_name: "Wardens of the Land"
+
+#  LEGACY_DYNASTY_GWYNTHORN_TILLERS_HERITAGE: "[stewardship|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('comely').GetName] or [GetTrait('quick').GetName] traits"
+
+#  LEGACY_DYNASTY_GWYNTHORN_RELENTLESS_LABOR: "[development_growth|E] in [realm_capital|E]: #P +10%#! and [building_construction_gold_cost|E]: #P -10%#!"
+
+#  LEGACY_DYNASTY_GWYNTHORN_STONE_AND_ROOT: "[domain_limit|E]: #P +1#! and [county_opinion|E]: #P +5#!"
+
+#  LEGACY_DYNASTY_GWYNTHORN_GOLDEN_HARVESTS: "[tax_income|E]: #P +5%#! and [holding_construction_time|E]: #P -15%#!"
+
+#  LEGACY_DYNASTY_GWYNTHORN_WARDENS_OF_THE_LAND: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('quick').GetName] or [GetTrait('beautiful').GetName] traits; [control_growth|E] in held counties: #P +0.3/month#!"

--- a/localization/english/legacies/gwynthorn_legacy_l_english.yml
+++ b/localization/english/legacies/gwynthorn_legacy_l_english.yml
@@ -1,20 +1,20 @@
-﻿# l_english:
+l_english:
 
-#  gwynthorn_legacy_track_name: "House Gwynthorn"
-#  gwynthorn_legacy_track_desc: "Tireless stewards and diligent caretakers, the Gwynthorn bloodline is marked by boundless energy, industrious hearts, and an unwavering commitment to the prosperity of their lands. Fields flourish and halls gleam wherever their kin dwell."
+ gwynthorn_legacy_track_name: "House Gwynthorn"
+ gwynthorn_legacy_track_desc: "Tireless stewards and diligent caretakers, the Gwynthorn bloodline is marked by boundless energy, industrious hearts, and an unwavering commitment to the prosperity of their lands. Fields flourish and halls gleam wherever their kin dwell."
 
-#  gwynthorn_legacy_1_name: "Tiller's Heritage"
-#  gwynthorn_legacy_2_name: "Relentless Labor"
-#  gwynthorn_legacy_3_name: "Stone and Root"
-#  gwynthorn_legacy_4_name: "Golden Harvests"
-#  gwynthorn_legacy_5_name: "Wardens of the Land"
+ gwynthorn_legacy_1_name: "Tiller's Heritage"
+ gwynthorn_legacy_2_name: "Relentless Labor"
+ gwynthorn_legacy_3_name: "Stone and Root"
+ gwynthorn_legacy_4_name: "Golden Harvests"
+ gwynthorn_legacy_5_name: "Wardens of the Land"
 
-#  LEGACY_DYNASTY_GWYNTHORN_TILLERS_HERITAGE: "[stewardship|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('comely').GetName] or [GetTrait('quick').GetName] traits"
+ LEGACY_DYNASTY_GWYNTHORN_TILLERS_HERITAGE: "[stewardship|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('comely').GetName] or [GetTrait('quick').GetName] traits"
 
-#  LEGACY_DYNASTY_GWYNTHORN_RELENTLESS_LABOR: "[development_growth|E] in [realm_capital|E]: #P +10%#! and [building_construction_gold_cost|E]: #P -10%#!"
+ LEGACY_DYNASTY_GWYNTHORN_RELENTLESS_LABOR: "[development_growth|E] in [realm_capital|E]: #P +10%#! and [building_construction_gold_cost|E]: #P -10%#!"
 
-#  LEGACY_DYNASTY_GWYNTHORN_STONE_AND_ROOT: "[domain_limit|E]: #P +1#! and [county_opinion|E]: #P +5#!"
+ LEGACY_DYNASTY_GWYNTHORN_STONE_AND_ROOT: "[domain_limit|E]: #P +1#! and [county_opinion|E]: #P +5#!"
 
-#  LEGACY_DYNASTY_GWYNTHORN_GOLDEN_HARVESTS: "[tax_income|E]: #P +5%#! and [holding_construction_time|E]: #P -15%#!"
+ LEGACY_DYNASTY_GWYNTHORN_GOLDEN_HARVESTS: "[tax_income|E]: #P +5%#! and [holding_construction_time|E]: #P -15%#!"
 
-#  LEGACY_DYNASTY_GWYNTHORN_WARDENS_OF_THE_LAND: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('quick').GetName] or [GetTrait('beautiful').GetName] traits; [control_growth|E] in held counties: #P +0.3/month#!"
+ LEGACY_DYNASTY_GWYNTHORN_WARDENS_OF_THE_LAND: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('quick').GetName] or [GetTrait('beautiful').GetName] traits; [control_growth|E] in held counties: #P +0.3/month#!"

--- a/localization/english/legacies/lormelis_legacy_l_english.yml
+++ b/localization/english/legacies/lormelis_legacy_l_english.yml
@@ -1,0 +1,20 @@
+﻿# l_english:
+
+#  lormelis_legacy_track_name: "House Lormelis"
+#  lormelis_legacy_track_desc: "The tides remember the glory of Atlantis. With the ocean in their blood and ambition in their hearts, the Lormelis ride the waves not just to raid — but to reclaim their lost dominion. Fiercely proud and dangerously unyielding, their legacy surges like a storm."
+
+#  lormelis_legacy_1_name: "Children of the Deep"
+#  lormelis_legacy_2_name: "Tideborn Raiders"
+#  lormelis_legacy_3_name: "Atlantean Ambition"
+#  lormelis_legacy_4_name: "Unbending Pride"
+#  lormelis_legacy_5_name: "Legacy of the Sea Lords"
+
+#  LEGACY_DYNASTY_LORMELIS_CHILDREN_OF_THE_DEEP: "[naval_speed|E]: #P +25%#! and no [embarkation_cost|E] for [dynasty_members|E]"
+
+#  LEGACY_DYNASTY_LORMELIS_TIDEBORN_RAIDERS: "[raid_loot|E] gain: #P +15%#! and reduced [county_control|E] loss in coastal holdings"
+
+#  LEGACY_DYNASTY_LORMELIS_ATLANTEAN_AMBITION: "Increased [prestige|E] gain from [battles|E] and [decisions|E]; minor bonus to [hostile_scheme_success_chance|E]"
+
+#  LEGACY_DYNASTY_LORMELIS_UNBENDING_PRIDE: "+10 [vassal_opinion|E] when [crown_authority|E] is High or Absolute; [control_growth|E] in capital: #P +15%#!"
+
+#  LEGACY_DYNASTY_LORMELIS_LEGACY_SEA_LORDS: "[dynasty_members|E] gain [prestige|E] from sea-themed traits (e.g., [GetTrait('adventurer').GetName], [GetTrait('raider').GetName]); coastal [development_growth|E]: #P +10%#!; #underline Lormelis bloodline#! has #P increased chance#! to pass on [congenital_traits|E]"

--- a/localization/english/legacies/lormelis_legacy_l_english.yml
+++ b/localization/english/legacies/lormelis_legacy_l_english.yml
@@ -1,20 +1,20 @@
-﻿# l_english:
+l_english:
 
-#  lormelis_legacy_track_name: "House Lormelis"
-#  lormelis_legacy_track_desc: "The tides remember the glory of Atlantis. With the ocean in their blood and ambition in their hearts, the Lormelis ride the waves not just to raid — but to reclaim their lost dominion. Fiercely proud and dangerously unyielding, their legacy surges like a storm."
+ lormelis_legacy_track_name: "House Lormelis"
+ lormelis_legacy_track_desc: "The tides remember the glory of Atlantis. With the ocean in their blood and ambition in their hearts, the Lormelis ride the waves not just to raid — but to reclaim their lost dominion. Fiercely proud and dangerously unyielding, their legacy surges like a storm."
 
-#  lormelis_legacy_1_name: "Children of the Deep"
-#  lormelis_legacy_2_name: "Tideborn Raiders"
-#  lormelis_legacy_3_name: "Atlantean Ambition"
-#  lormelis_legacy_4_name: "Unbending Pride"
-#  lormelis_legacy_5_name: "Legacy of the Sea Lords"
+ lormelis_legacy_1_name: "Children of the Deep"
+ lormelis_legacy_2_name: "Tideborn Raiders"
+ lormelis_legacy_3_name: "Atlantean Ambition"
+ lormelis_legacy_4_name: "Unbending Pride"
+ lormelis_legacy_5_name: "Legacy of the Sea Lords"
 
-#  LEGACY_DYNASTY_LORMELIS_CHILDREN_OF_THE_DEEP: "[naval_speed|E]: #P +25%#! and no [embarkation_cost|E] for [dynasty_members|E]"
+ LEGACY_DYNASTY_LORMELIS_CHILDREN_OF_THE_DEEP: "[naval_speed|E]: #P +25%#! and no [embarkation_cost|E] for [dynasty_members|E]"
 
-#  LEGACY_DYNASTY_LORMELIS_TIDEBORN_RAIDERS: "[raid_loot|E] gain: #P +15%#! and reduced [county_control|E] loss in coastal holdings"
+ LEGACY_DYNASTY_LORMELIS_TIDEBORN_RAIDERS: "[raid_loot|E] gain: #P +15%#! and reduced [county_control|E] loss in coastal holdings"
 
-#  LEGACY_DYNASTY_LORMELIS_ATLANTEAN_AMBITION: "Increased [prestige|E] gain from [battles|E] and [decisions|E]; minor bonus to [hostile_scheme_success_chance|E]"
+ LEGACY_DYNASTY_LORMELIS_ATLANTEAN_AMBITION: "Increased [prestige|E] gain from [battles|E] and [decisions|E]; minor bonus to [hostile_scheme_success_chance|E]"
 
-#  LEGACY_DYNASTY_LORMELIS_UNBENDING_PRIDE: "+10 [vassal_opinion|E] when [crown_authority|E] is High or Absolute; [control_growth|E] in capital: #P +15%#!"
+ LEGACY_DYNASTY_LORMELIS_UNBENDING_PRIDE: "+10 [vassal_opinion|E] when [crown_authority|E] is High or Absolute; [control_growth|E] in capital: #P +15%#!"
 
-#  LEGACY_DYNASTY_LORMELIS_LEGACY_SEA_LORDS: "[dynasty_members|E] gain [prestige|E] from sea-themed traits (e.g., [GetTrait('adventurer').GetName], [GetTrait('raider').GetName]); coastal [development_growth|E]: #P +10%#!; #underline Lormelis bloodline#! has #P increased chance#! to pass on [congenital_traits|E]"
+ LEGACY_DYNASTY_LORMELIS_LEGACY_SEA_LORDS: "[dynasty_members|E] gain [prestige|E] from sea-themed traits (e.g., [GetTrait('adventurer').GetName], [GetTrait('raider').GetName]); coastal [development_growth|E]: #P +10%#!; #underline Lormelis bloodline#! has #P increased chance#! to pass on [congenital_traits|E]"

--- a/localization/english/legacies/serelion_legacy_l_english.yml
+++ b/localization/english/legacies/serelion_legacy_l_english.yml
@@ -1,0 +1,22 @@
+﻿# l_english:
+
+#  daelurin_legacy_track_name: "House Daelurin"
+#  daelurin_legacy_track_desc: "From the mountains of shadow and starlight come the towering warriors of Daelurin, bred for battle, mastery of the blade, and supernatural feats of might. Their bloodlines produce beings of immense physical power, whose war-cries shake the hearts of men."
+
+#  daelurin_legacy_1_name: "Waking the Blood"
+#  daelurin_legacy_2_name: "Iron Discipline"
+#  daelurin_legacy_3_name: "Art of War"
+#  daelurin_legacy_4_name: "Crushing Blows"
+#  daelurin_legacy_5_name: "Living Legends"
+
+#  LEGACY_DYNASTY_DAELURIN_UNLOCK_UNITS: "Unlocks the [GetMaA('️daelurin_whitevale_warriors').GetName], [GetMaA('wolf_riders').GetName], and [GetMaA('daelurin_highlanders').GetName] [men_at_arms|E] unique to House Daelurin"
+
+#  LEGACY_DYNASTY_DAELURIN_WAKING_THE_BLOOD: "[prowess|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('strong').GetName] or [GetTrait('giant').GetName] traits"
+
+#  LEGACY_DYNASTY_DAELURIN_IRON_DISCIPLINE: "[knight_effectiveness|E]: #P +15%#! and [men_at_arms_damage_mult|E]: #P +5%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_ART_OF_WAR: "[martial_lifestyle_experience|E]: #P +15%#! and monthly [prestige|E]: #P +10%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_CRUSHING_BLOWS: "[knight_damage_mult|E]: #P +25%#! and [enemy_combat_pursuit_damage_taken_mult|E]: #P +10%#!"
+
+#  LEGACY_DYNASTY_DAELURIN_LIVING_LEGENDS_EFFECT: "Increased chance for [dynasty_members|E] to be born with [GetTrait('strong').GetName], [GetTrait('giant').GetName], or [GetTrait('quick').GetName]; unlocks the ability to commission heroic statues to their feats"

--- a/localization/english/legacies/serelion_legacy_l_english.yml
+++ b/localization/english/legacies/serelion_legacy_l_english.yml
@@ -1,22 +1,19 @@
-﻿# l_english:
+l_english:
+ serelion_legacy_track_name: "House Serelion"
+ serelion_legacy_track_desc: "Born beneath the ancient boughs of the Whispering Woods, the Serelion are masters of shadow and bowstring. Their bloodline carries the instincts of predator and guardian alike — swift, silent, and at one with the living forest that has sheltered them since before memory."
 
-#  daelurin_legacy_track_name: "House Daelurin"
-#  daelurin_legacy_track_desc: "From the mountains of shadow and starlight come the towering warriors of Daelurin, bred for battle, mastery of the blade, and supernatural feats of might. Their bloodlines produce beings of immense physical power, whose war-cries shake the hearts of men."
+ serelion_legacy_1_name: "Eyes of the Forest"
+ serelion_legacy_2_name: "Whisper Step"
+ serelion_legacy_3_name: "Song of the Ancient Boughs"
+ serelion_legacy_4_name: "Moonlit Arrows"
+ serelion_legacy_5_name: "Eternal Wardens"
 
-#  daelurin_legacy_1_name: "Waking the Blood"
-#  daelurin_legacy_2_name: "Iron Discipline"
-#  daelurin_legacy_3_name: "Art of War"
-#  daelurin_legacy_4_name: "Crushing Blows"
-#  daelurin_legacy_5_name: "Living Legends"
+ LEGACY_DYNASTY_SERELION_EYES_OF_THE_FOREST: "[intrigue|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('feral').GetName] or [GetTrait('keen_sight').GetName] traits"
 
-#  LEGACY_DYNASTY_DAELURIN_UNLOCK_UNITS: "Unlocks the [GetMaA('️daelurin_whitevale_warriors').GetName], [GetMaA('wolf_riders').GetName], and [GetMaA('daelurin_highlanders').GetName] [men_at_arms|E] unique to House Daelurin"
+ LEGACY_DYNASTY_SERELION_WHISPER_STEP: "[hostile_scheme_success_chance|E]: #P +10%#! and [scheme_discovery_chance|E] against [dynasty_members|E]: #N -10%#!"
 
-#  LEGACY_DYNASTY_DAELURIN_WAKING_THE_BLOOD: "[prowess|E] for [dynasty_members|E]: #P +2#! and increased chance of inheriting the [GetTrait('strong').GetName] or [GetTrait('giant').GetName] traits"
+ LEGACY_DYNASTY_SERELION_SONG_OF_THE_BOUGHS: "[monthly_prestige|E]: #P +10%#! from forest holdings and [forest_combat_advantage|E]: #P +3#! for [dynasty_members|E] fighting in woodland terrain"
 
-#  LEGACY_DYNASTY_DAELURIN_IRON_DISCIPLINE: "[knight_effectiveness|E]: #P +15%#! and [men_at_arms_damage_mult|E]: #P +5%#!"
+ LEGACY_DYNASTY_SERELION_MOONLIT_ARROWS: "[archer_effectiveness|E]: #P +20%#! and [archer_damage_mult|E]: #P +10%#! for levies and [men_at_arms|E] raised by [dynasty_members|E]"
 
-#  LEGACY_DYNASTY_DAELURIN_ART_OF_WAR: "[martial_lifestyle_experience|E]: #P +15%#! and monthly [prestige|E]: #P +10%#!"
-
-#  LEGACY_DYNASTY_DAELURIN_CRUSHING_BLOWS: "[knight_damage_mult|E]: #P +25%#! and [enemy_combat_pursuit_damage_taken_mult|E]: #P +10%#!"
-
-#  LEGACY_DYNASTY_DAELURIN_LIVING_LEGENDS_EFFECT: "Increased chance for [dynasty_members|E] to be born with [GetTrait('strong').GetName], [GetTrait('giant').GetName], or [GetTrait('quick').GetName]; unlocks the ability to commission heroic statues to their feats"
+ LEGACY_DYNASTY_SERELION_ETERNAL_WARDENS: "[dynasty_members|E] gain increased chance to be born with the [GetTrait('feral').GetName] or [GetTrait('patient').GetName] traits; [ranger_effectiveness|E]: #P +25%#! and ambush chance in forest battles: #P +15%#!"

--- a/localization/english/legacies/thundarael_legacy_l_english.yml
+++ b/localization/english/legacies/thundarael_legacy_l_english.yml
@@ -1,0 +1,20 @@
+﻿# l_english:
+
+#  thundarael_legacy_track_name: "House Thundarael"
+#  thundarael_legacy_track_desc: "The blood of Thundarael runs wild with storm-born brilliance. Pale and luminous, their minds burn with insight beyond mortal comprehension. They learn faster, move quicker, and strike with terrifying unpredictability — though madness ever waits in the margins of such power."
+
+#  thundarael_legacy_1_name: "Storm-Born Minds"
+#  thundarael_legacy_2_name: "Lightning Reflexes"
+#  thundarael_legacy_3_name: "Whispers in the Void"
+#  thundarael_legacy_4_name: "Arcane Ascendancy"
+#  thundarael_legacy_5_name: "Gaze of the Unbound"
+
+#  LEGACY_DYNASTY_THUNDARAEL_STORM_BORN_MINDS: "[learning|E] for [dynasty_members|E]: #P +2#! and [lifestyle_experience|E] gain: #P +15%#!"
+
+#  LEGACY_DYNASTY_THUNDARAEL_LIGHTNING_REFLEXES: "[scheme_discovery_chance|E]: #P +10%#! and [enemy_hostile_scheme_success_chance|E]: #N -10%#!"
+
+#  LEGACY_DYNASTY_THUNDARAEL_WHISPERS_VOID: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('intelligent').GetName] or [GetTrait('quick').GetName] traits; [secrets|E] are more easily discovered"
+
+#  LEGACY_DYNASTY_THUNDARAEL_ARCANE_ASCENDANCY: "[personal_scheme_power|E]: #P +20%#! and [stress_loss|E] from [learning|E] activities"
+
+#  LEGACY_DYNASTY_THUNDARAEL_GAZE_UNBOUND: "[dynasty_members|E] are more likely to receive rare education traits (e.g., [GetTrait('lifestyle_scholar').GetName], [GetTrait('lifestyle_mystic').GetName]); hostile [schemes|E] against them are less effective"

--- a/localization/english/legacies/thundarael_legacy_l_english.yml
+++ b/localization/english/legacies/thundarael_legacy_l_english.yml
@@ -1,20 +1,20 @@
-﻿# l_english:
+l_english:
 
-#  thundarael_legacy_track_name: "House Thundarael"
-#  thundarael_legacy_track_desc: "The blood of Thundarael runs wild with storm-born brilliance. Pale and luminous, their minds burn with insight beyond mortal comprehension. They learn faster, move quicker, and strike with terrifying unpredictability — though madness ever waits in the margins of such power."
+ thundarael_legacy_track_name: "House Thundarael"
+ thundarael_legacy_track_desc: "The blood of Thundarael runs wild with storm-born brilliance. Pale and luminous, their minds burn with insight beyond mortal comprehension. They learn faster, move quicker, and strike with terrifying unpredictability — though madness ever waits in the margins of such power."
 
-#  thundarael_legacy_1_name: "Storm-Born Minds"
-#  thundarael_legacy_2_name: "Lightning Reflexes"
-#  thundarael_legacy_3_name: "Whispers in the Void"
-#  thundarael_legacy_4_name: "Arcane Ascendancy"
-#  thundarael_legacy_5_name: "Gaze of the Unbound"
+ thundarael_legacy_1_name: "Storm-Born Minds"
+ thundarael_legacy_2_name: "Lightning Reflexes"
+ thundarael_legacy_3_name: "Whispers in the Void"
+ thundarael_legacy_4_name: "Arcane Ascendancy"
+ thundarael_legacy_5_name: "Gaze of the Unbound"
 
-#  LEGACY_DYNASTY_THUNDARAEL_STORM_BORN_MINDS: "[learning|E] for [dynasty_members|E]: #P +2#! and [lifestyle_experience|E] gain: #P +15%#!"
+ LEGACY_DYNASTY_THUNDARAEL_STORM_BORN_MINDS: "[learning|E] for [dynasty_members|E]: #P +2#! and [lifestyle_experience|E] gain: #P +15%#!"
 
-#  LEGACY_DYNASTY_THUNDARAEL_LIGHTNING_REFLEXES: "[scheme_discovery_chance|E]: #P +10%#! and [enemy_hostile_scheme_success_chance|E]: #N -10%#!"
+ LEGACY_DYNASTY_THUNDARAEL_LIGHTNING_REFLEXES: "[scheme_discovery_chance|E]: #P +10%#! and [enemy_hostile_scheme_success_chance|E]: #N -10%#!"
 
-#  LEGACY_DYNASTY_THUNDARAEL_WHISPERS_VOID: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('intelligent').GetName] or [GetTrait('quick').GetName] traits; [secrets|E] are more easily discovered"
+ LEGACY_DYNASTY_THUNDARAEL_WHISPERS_VOID: "Increased chance for [dynasty_members|E] to be born with the [GetTrait('intelligent').GetName] or [GetTrait('quick').GetName] traits; [secrets|E] are more easily discovered"
 
-#  LEGACY_DYNASTY_THUNDARAEL_ARCANE_ASCENDANCY: "[personal_scheme_power|E]: #P +20%#! and [stress_loss|E] from [learning|E] activities"
+ LEGACY_DYNASTY_THUNDARAEL_ARCANE_ASCENDANCY: "[personal_scheme_power|E]: #P +20%#! and [stress_loss|E] from [learning|E] activities"
 
-#  LEGACY_DYNASTY_THUNDARAEL_GAZE_UNBOUND: "[dynasty_members|E] are more likely to receive rare education traits (e.g., [GetTrait('lifestyle_scholar').GetName], [GetTrait('lifestyle_mystic').GetName]); hostile [schemes|E] against them are less effective"
+ LEGACY_DYNASTY_THUNDARAEL_GAZE_UNBOUND: "[dynasty_members|E] are more likely to receive rare education traits (e.g., [GetTrait('lifestyle_scholar').GetName], [GetTrait('lifestyle_mystic').GetName]); hostile [schemes|E] against them are less effective"

--- a/localization/english/legacies/valerith_legacy_l_english.yml
+++ b/localization/english/legacies/valerith_legacy_l_english.yml
@@ -1,0 +1,20 @@
+﻿# l_english:
+
+#  valerith_legacy_track_name: "House Valerith"
+#  valerith_legacy_track_desc: "Silver-haired and enchantingly graceful, the Valerith line have ruled courts and kingdoms through charm rather than steel. Their legacy is one of elegance, sensuality, and unrivaled courtly influence — a beauty so dangerous, it turns even the strongest hearts to glass."
+
+#  valerith_legacy_1_name: "Silver Tongues"
+#  valerith_legacy_2_name: "Veil of Grace"
+#  valerith_legacy_3_name: "Velvet Chains"
+#  valerith_legacy_4_name: "Court of Thorns"
+#  valerith_legacy_5_name: "Incarnate Elegance"
+
+#  LEGACY_DYNASTY_VALERITH_SILVER_TONGUES: "[diplomacy|E] for [dynasty_members|E]: #P +2#! and increased success chance for [personal_scheme|E]s"
+
+#  LEGACY_DYNASTY_VALERITH_VEIL_OF_GRACE: "Increased chance to inherit the [GetTrait('comely').GetName] or [GetTrait('beautiful').GetName] traits"
+
+#  LEGACY_DYNASTY_VALERITH_VELVET_CHAINS: "[seduction_scheme_power|E]: #P +25%#! and [court_seduction|E] schemes are less likely to be discovered"
+
+#  LEGACY_DYNASTY_VALERITH_COURT_OF_THORNS: "[court_grandeur_bonus|E]: #P +3#! and [courtier|E] attraction opinion: #P +10#!"
+
+#  LEGACY_DYNASTY_VALERITH_INCARNATE_ELEGANCE: "[dynasty_members|E] gain increased chance to be born with the [GetTrait('beautiful').GetName] or [GetTrait('quick').GetName] traits; [prestige|E] from [personal_schemes|E]: #P +25%#!"

--- a/localization/english/legacies/valerith_legacy_l_english.yml
+++ b/localization/english/legacies/valerith_legacy_l_english.yml
@@ -1,20 +1,20 @@
-﻿# l_english:
+l_english:
 
-#  valerith_legacy_track_name: "House Valerith"
-#  valerith_legacy_track_desc: "Silver-haired and enchantingly graceful, the Valerith line have ruled courts and kingdoms through charm rather than steel. Their legacy is one of elegance, sensuality, and unrivaled courtly influence — a beauty so dangerous, it turns even the strongest hearts to glass."
+ valerith_legacy_track_name: "House Valerith"
+ valerith_legacy_track_desc: "Silver-haired and enchantingly graceful, the Valerith line have ruled courts and kingdoms through charm rather than steel. Their legacy is one of elegance, sensuality, and unrivaled courtly influence — a beauty so dangerous, it turns even the strongest hearts to glass."
 
-#  valerith_legacy_1_name: "Silver Tongues"
-#  valerith_legacy_2_name: "Veil of Grace"
-#  valerith_legacy_3_name: "Velvet Chains"
-#  valerith_legacy_4_name: "Court of Thorns"
-#  valerith_legacy_5_name: "Incarnate Elegance"
+ valerith_legacy_1_name: "Silver Tongues"
+ valerith_legacy_2_name: "Veil of Grace"
+ valerith_legacy_3_name: "Velvet Chains"
+ valerith_legacy_4_name: "Court of Thorns"
+ valerith_legacy_5_name: "Incarnate Elegance"
 
-#  LEGACY_DYNASTY_VALERITH_SILVER_TONGUES: "[diplomacy|E] for [dynasty_members|E]: #P +2#! and increased success chance for [personal_scheme|E]s"
+ LEGACY_DYNASTY_VALERITH_SILVER_TONGUES: "[diplomacy|E] for [dynasty_members|E]: #P +2#! and increased success chance for [personal_scheme|E]s"
 
-#  LEGACY_DYNASTY_VALERITH_VEIL_OF_GRACE: "Increased chance to inherit the [GetTrait('comely').GetName] or [GetTrait('beautiful').GetName] traits"
+ LEGACY_DYNASTY_VALERITH_VEIL_OF_GRACE: "Increased chance to inherit the [GetTrait('comely').GetName] or [GetTrait('beautiful').GetName] traits"
 
-#  LEGACY_DYNASTY_VALERITH_VELVET_CHAINS: "[seduction_scheme_power|E]: #P +25%#! and [court_seduction|E] schemes are less likely to be discovered"
+ LEGACY_DYNASTY_VALERITH_VELVET_CHAINS: "[seduction_scheme_power|E]: #P +25%#! and [court_seduction|E] schemes are less likely to be discovered"
 
-#  LEGACY_DYNASTY_VALERITH_COURT_OF_THORNS: "[court_grandeur_bonus|E]: #P +3#! and [courtier|E] attraction opinion: #P +10#!"
+ LEGACY_DYNASTY_VALERITH_COURT_OF_THORNS: "[court_grandeur_bonus|E]: #P +3#! and [courtier|E] attraction opinion: #P +10#!"
 
-#  LEGACY_DYNASTY_VALERITH_INCARNATE_ELEGANCE: "[dynasty_members|E] gain increased chance to be born with the [GetTrait('beautiful').GetName] or [GetTrait('quick').GetName] traits; [prestige|E] from [personal_schemes|E]: #P +25%#!"
+ LEGACY_DYNASTY_VALERITH_INCARNATE_ELEGANCE: "[dynasty_members|E] gain increased chance to be born with the [GetTrait('beautiful').GetName] or [GetTrait('quick').GetName] traits; [prestige|E] from [personal_schemes|E]: #P +25%#!"


### PR DESCRIPTION
## Summary
- Adds 6 dynasty legacy tracks (valerith, daelurin, serelion, gwynthorn, thundarael, lormelis) and 1 perk stub
- Fixed source WIP: all content was commented out in source — uncommented everything
- Rewrote serelion legacy localization (was a copy of daelurin) with proper forest-elf archery/stealth theme
- Stripped BOM, converted CRLF→LF, removed invisible U+FE0F character from daelurin localization
- Note: `is_valerith_trigger` is referenced but undefined (WIP from source); daelurin/other perks are stubs with no effects yet

## Merge order
No dependencies — can merge independently.

## Test plan
- [ ] Verify dynasty legacy tracks appear for elven dynasties in the dynasty view